### PR TITLE
feat(comments): show all categories + share   comment as image card

### DIFF
--- a/nextjs/cypress/e2e/comment-share.cy.ts
+++ b/nextjs/cypress/e2e/comment-share.cy.ts
@@ -16,11 +16,13 @@ function getVerseId(
   return cy
     .request("GET", `/api/books/${abbrev}/verses/${chapter}`)
     .then((res) => {
-      const v = (res.body as Array<{ _id: string; verseNumber: number }>).find(
-        (x) => x.verseNumber === verseNumber,
-      );
-      expect(v, `verse ${abbrev} ${chapter}:${verseNumber}`).to.exist;
-      return v!._id;
+      const verse = (
+        res.body as Array<{ _id: string; verseNumber: number }>
+      ).find((item) => item.verseNumber === verseNumber);
+      if (!verse) {
+        throw new Error(`verse ${abbrev} ${chapter}:${verseNumber} missing`);
+      }
+      return verse._id;
     });
 }
 
@@ -28,7 +30,9 @@ describe("Multi-category badges + share card", () => {
   beforeEach(() => {
     cy.resetDb();
     cy.seedDb({
-      users: [users.alice],
+      // chapter tutorial pre-completed — its coach-mark overlay otherwise
+      // covers the reader panel and blocks the share button.
+      users: [{ ...users.alice, tutorialsCompleted: ["chapter-v1"] }],
       books: [bookFixture.book],
       verses: bookFixture.verses,
     });

--- a/nextjs/cypress/e2e/comment-share.cy.ts
+++ b/nextjs/cypress/e2e/comment-share.cy.ts
@@ -1,0 +1,101 @@
+/**
+ * Feature coverage (verified on CI — local Cypress is unusable):
+ *  - Multi-category comments render ALL tag pills, ordered most personal →
+ *    most studied; empty tags fall back to the neutral "Comentário".
+ *  - Share-as-image: button in the reader footer opens a preview modal;
+ *    the canonical /c/<id> link and the OG image endpoint respond.
+ */
+import users from "../fixtures/users.json";
+import bookFixture from "../fixtures/book-gn.json";
+
+function getVerseId(
+  abbrev: string,
+  chapter: number,
+  verseNumber: number,
+): Cypress.Chainable<string> {
+  return cy
+    .request("GET", `/api/books/${abbrev}/verses/${chapter}`)
+    .then((res) => {
+      const v = (res.body as Array<{ _id: string; verseNumber: number }>).find(
+        (x) => x.verseNumber === verseNumber,
+      );
+      expect(v, `verse ${abbrev} ${chapter}:${verseNumber}`).to.exist;
+      return v!._id;
+    });
+}
+
+describe("Multi-category badges + share card", () => {
+  beforeEach(() => {
+    cy.resetDb();
+    cy.seedDb({
+      users: [users.alice],
+      books: [bookFixture.book],
+      verses: bookFixture.verses,
+    });
+    cy.loginAs(users.alice.email, users.alice.password);
+  });
+
+  it("renders every category, ordered most personal → most studied", () => {
+    getVerseId("gn", 1, 1).then((verseId) => {
+      cy.request("POST", `/api/comments/${verseId}`, {
+        text: "comentário multi-categoria",
+        tags: ["exegese", "pessoal"],
+      });
+      cy.visit("/verses/gn/1");
+      cy.get("li#1 button").first().click();
+      cy.contains("comentário multi-categoria").should("be.visible");
+      cy.get('[data-testid="tag-badges"]')
+        .filter(':contains("Pessoal")')
+        .first()
+        .within(() => {
+          cy.contains("Pessoal").should("be.visible");
+          cy.contains("Exegese").should("be.visible");
+        });
+    });
+  });
+
+  it("falls back to the neutral 'Comentário' badge when there are no tags", () => {
+    getVerseId("gn", 1, 1).then((verseId) => {
+      cy.request("POST", `/api/comments/${verseId}`, {
+        text: "comentário sem categoria",
+        tags: [],
+      });
+      cy.visit("/verses/gn/1");
+      cy.get("li#1 button").first().click();
+      cy.contains("comentário sem categoria").should("be.visible");
+      cy.get('[data-testid="tag-badges"]')
+        .filter(':contains("Comentário")')
+        .should("exist");
+    });
+  });
+
+  it("share button opens a preview modal; /c/<id> and OG image respond", () => {
+    getVerseId("gn", 1, 1).then((verseId) => {
+      cy.request("POST", `/api/comments/${verseId}`, {
+        text: "comentário para compartilhar",
+        tags: ["devocional"],
+      }).then((res) => {
+        const id = res.body._id as string;
+
+        cy.visit("/verses/gn/1");
+        cy.get("li#1 button").first().click();
+        cy.contains("comentário para compartilhar").should("be.visible");
+
+        cy.get('[aria-label="Compartilhar comentário"]').first().click();
+        cy.get('[role="dialog"], [aria-label="Compartilhar comentário"]')
+          .should("exist");
+        cy.get('img[alt="Pré-visualização do card do comentário"]')
+          .should("have.attr", "src")
+          .and("include", `/api/og/comment/${id}`);
+
+        cy.request(`/api/og/comment/${id}`).then((r) => {
+          expect(r.status).to.eq(200);
+          expect(r.headers["content-type"]).to.include("image/png");
+        });
+        cy.request(`/c/${id}`).then((r) => {
+          expect(r.status).to.eq(200);
+        });
+      });
+    });
+  });
+});

--- a/nextjs/cypress/e2e/comment-share.cy.ts
+++ b/nextjs/cypress/e2e/comment-share.cy.ts
@@ -86,9 +86,9 @@ describe("Multi-category badges + share card", () => {
 				cy.contains("comentário para compartilhar").should("be.visible");
 
 				cy.get('[aria-label="Compartilhar comentário"]').first().click();
-				cy.get(
-					'[role="dialog"], [aria-label="Compartilhar comentário"]',
-				).should("exist");
+				// Assert the modal itself opened — not the trigger button,
+				// which also carries aria-label="Compartilhar comentário".
+				cy.get('[role="dialog"]').should("be.visible");
 				cy.get('img[alt="Pré-visualização do card do comentário"]')
 					.should("have.attr", "src")
 					.and("include", `/api/og/comment/${id}`);

--- a/nextjs/cypress/e2e/comment-share.cy.ts
+++ b/nextjs/cypress/e2e/comment-share.cy.ts
@@ -9,97 +9,98 @@ import users from "../fixtures/users.json";
 import bookFixture from "../fixtures/book-gn.json";
 
 function getVerseId(
-  abbrev: string,
-  chapter: number,
-  verseNumber: number,
+	abbrev: string,
+	chapter: number,
+	verseNumber: number,
 ): Cypress.Chainable<string> {
-  return cy
-    .request("GET", `/api/books/${abbrev}/verses/${chapter}`)
-    .then((res) => {
-      const verse = (
-        res.body as Array<{ _id: string; verseNumber: number }>
-      ).find((item) => item.verseNumber === verseNumber);
-      if (!verse) {
-        throw new Error(`verse ${abbrev} ${chapter}:${verseNumber} missing`);
-      }
-      return verse._id;
-    });
+	return cy
+		.request("GET", `/api/books/${abbrev}/verses/${chapter}`)
+		.then((res) => {
+			const verse = (
+				res.body as Array<{ _id: string; verseNumber: number }>
+			).find((item) => item.verseNumber === verseNumber);
+			if (!verse) {
+				throw new Error(`verse ${abbrev} ${chapter}:${verseNumber} missing`);
+			}
+			return verse._id;
+		});
 }
 
 describe("Multi-category badges + share card", () => {
-  beforeEach(() => {
-    cy.resetDb();
-    cy.seedDb({
-      // chapter tutorial pre-completed — its coach-mark overlay otherwise
-      // covers the reader panel and blocks the share button.
-      users: [{ ...users.alice, tutorialsCompleted: ["chapter-v1"] }],
-      books: [bookFixture.book],
-      verses: bookFixture.verses,
-    });
-    cy.loginAs(users.alice.email, users.alice.password);
-  });
+	beforeEach(() => {
+		cy.resetDb();
+		cy.seedDb({
+			// chapter tutorial pre-completed — its coach-mark overlay otherwise
+			// covers the reader panel and blocks the share button.
+			users: [{ ...users.alice, tutorialsCompleted: ["chapter-v1"] }],
+			books: [bookFixture.book],
+			verses: bookFixture.verses,
+		});
+		cy.loginAs(users.alice.email, users.alice.password);
+	});
 
-  it("renders every category, ordered most personal → most studied", () => {
-    getVerseId("gn", 1, 1).then((verseId) => {
-      cy.request("POST", `/api/comments/${verseId}`, {
-        text: "comentário multi-categoria",
-        tags: ["exegese", "pessoal"],
-      });
-      cy.visit("/verses/gn/1");
-      cy.get("li#1 button").first().click();
-      cy.contains("comentário multi-categoria").should("be.visible");
-      cy.get('[data-testid="tag-badges"]')
-        .filter(':contains("Pessoal")')
-        .first()
-        .within(() => {
-          cy.contains("Pessoal").should("be.visible");
-          cy.contains("Exegese").should("be.visible");
-        });
-    });
-  });
+	it("renders every category, ordered most personal → most studied", () => {
+		getVerseId("gn", 1, 1).then((verseId) => {
+			cy.request("POST", `/api/comments/${verseId}`, {
+				text: "comentário multi-categoria",
+				tags: ["exegese", "pessoal"],
+			});
+			cy.visit("/verses/gn/1");
+			cy.get("li#1 button").first().click();
+			cy.contains("comentário multi-categoria").should("be.visible");
+			cy.get('[data-testid="tag-badges"]')
+				.filter(':contains("Pessoal")')
+				.first()
+				.within(() => {
+					cy.contains("Pessoal").should("be.visible");
+					cy.contains("Exegese").should("be.visible");
+				});
+		});
+	});
 
-  it("falls back to the neutral 'Comentário' badge when there are no tags", () => {
-    getVerseId("gn", 1, 1).then((verseId) => {
-      cy.request("POST", `/api/comments/${verseId}`, {
-        text: "comentário sem categoria",
-        tags: [],
-      });
-      cy.visit("/verses/gn/1");
-      cy.get("li#1 button").first().click();
-      cy.contains("comentário sem categoria").should("be.visible");
-      cy.get('[data-testid="tag-badges"]')
-        .filter(':contains("Comentário")')
-        .should("exist");
-    });
-  });
+	it("falls back to the neutral 'Comentário' badge when there are no tags", () => {
+		getVerseId("gn", 1, 1).then((verseId) => {
+			cy.request("POST", `/api/comments/${verseId}`, {
+				text: "comentário sem categoria",
+				tags: [],
+			});
+			cy.visit("/verses/gn/1");
+			cy.get("li#1 button").first().click();
+			cy.contains("comentário sem categoria").should("be.visible");
+			cy.get('[data-testid="tag-badges"]')
+				.filter(':contains("Comentário")')
+				.should("exist");
+		});
+	});
 
-  it("share button opens a preview modal; /c/<id> and OG image respond", () => {
-    getVerseId("gn", 1, 1).then((verseId) => {
-      cy.request("POST", `/api/comments/${verseId}`, {
-        text: "comentário para compartilhar",
-        tags: ["devocional"],
-      }).then((res) => {
-        const id = res.body._id as string;
+	it("share button opens a preview modal; /c/<id> and OG image respond", () => {
+		getVerseId("gn", 1, 1).then((verseId) => {
+			cy.request("POST", `/api/comments/${verseId}`, {
+				text: "comentário para compartilhar",
+				tags: ["devocional"],
+			}).then((res) => {
+				const id = res.body._id as string;
 
-        cy.visit("/verses/gn/1");
-        cy.get("li#1 button").first().click();
-        cy.contains("comentário para compartilhar").should("be.visible");
+				cy.visit("/verses/gn/1");
+				cy.get("li#1 button").first().click();
+				cy.contains("comentário para compartilhar").should("be.visible");
 
-        cy.get('[aria-label="Compartilhar comentário"]').first().click();
-        cy.get('[role="dialog"], [aria-label="Compartilhar comentário"]')
-          .should("exist");
-        cy.get('img[alt="Pré-visualização do card do comentário"]')
-          .should("have.attr", "src")
-          .and("include", `/api/og/comment/${id}`);
+				cy.get('[aria-label="Compartilhar comentário"]').first().click();
+				cy.get(
+					'[role="dialog"], [aria-label="Compartilhar comentário"]',
+				).should("exist");
+				cy.get('img[alt="Pré-visualização do card do comentário"]')
+					.should("have.attr", "src")
+					.and("include", `/api/og/comment/${id}`);
 
-        cy.request(`/api/og/comment/${id}`).then((r) => {
-          expect(r.status).to.eq(200);
-          expect(r.headers["content-type"]).to.include("image/png");
-        });
-        cy.request(`/c/${id}`).then((r) => {
-          expect(r.status).to.eq(200);
-        });
-      });
-    });
-  });
+				cy.request(`/api/og/comment/${id}`).then((r) => {
+					expect(r.status).to.eq(200);
+					expect(r.headers["content-type"]).to.include("image/png");
+				});
+				cy.request(`/c/${id}`).then((r) => {
+					expect(r.status).to.eq(200);
+				});
+			});
+		});
+	});
 });

--- a/nextjs/cypress/e2e/comment-share.cy.ts
+++ b/nextjs/cypress/e2e/comment-share.cy.ts
@@ -9,93 +9,94 @@ import users from "../fixtures/users.json";
 import bookFixture from "../fixtures/book-gn.json";
 
 function getVerseId(
-  abbrev: string,
-  chapter: number,
-  verseNumber: number,
+	abbrev: string,
+	chapter: number,
+	verseNumber: number,
 ): Cypress.Chainable<string> {
-  return cy
-    .request("GET", `/api/books/${abbrev}/verses/${chapter}`)
-    .then((res) => {
-      const v = (res.body as Array<{ _id: string; verseNumber: number }>).find(
-        (x) => x.verseNumber === verseNumber,
-      );
-      expect(v, `verse ${abbrev} ${chapter}:${verseNumber}`).to.exist;
-      return v!._id;
-    });
+	return cy
+		.request("GET", `/api/books/${abbrev}/verses/${chapter}`)
+		.then((res) => {
+			const v = (res.body as Array<{ _id: string; verseNumber: number }>).find(
+				(x) => x.verseNumber === verseNumber,
+			);
+			expect(v, `verse ${abbrev} ${chapter}:${verseNumber}`).to.exist;
+			return v!._id;
+		});
 }
 
 describe("Multi-category badges + share card", () => {
-  beforeEach(() => {
-    cy.resetDb();
-    cy.seedDb({
-      users: [users.alice],
-      books: [bookFixture.book],
-      verses: bookFixture.verses,
-    });
-    cy.loginAs(users.alice.email, users.alice.password);
-  });
+	beforeEach(() => {
+		cy.resetDb();
+		cy.seedDb({
+			users: [users.alice],
+			books: [bookFixture.book],
+			verses: bookFixture.verses,
+		});
+		cy.loginAs(users.alice.email, users.alice.password);
+	});
 
-  it("renders every category, ordered most personal → most studied", () => {
-    getVerseId("gn", 1, 1).then((verseId) => {
-      cy.request("POST", `/api/comments/${verseId}`, {
-        text: "comentário multi-categoria",
-        tags: ["exegese", "pessoal"],
-      });
-      cy.visit("/verses/gn/1");
-      cy.get("li#1 button").first().click();
-      cy.contains("comentário multi-categoria").should("be.visible");
-      cy.get('[data-testid="tag-badges"]')
-        .filter(':contains("Pessoal")')
-        .first()
-        .within(() => {
-          cy.contains("Pessoal").should("be.visible");
-          cy.contains("Exegese").should("be.visible");
-        });
-    });
-  });
+	it("renders every category, ordered most personal → most studied", () => {
+		getVerseId("gn", 1, 1).then((verseId) => {
+			cy.request("POST", `/api/comments/${verseId}`, {
+				text: "comentário multi-categoria",
+				tags: ["exegese", "pessoal"],
+			});
+			cy.visit("/verses/gn/1");
+			cy.get("li#1 button").first().click();
+			cy.contains("comentário multi-categoria").should("be.visible");
+			cy.get('[data-testid="tag-badges"]')
+				.filter(':contains("Pessoal")')
+				.first()
+				.within(() => {
+					cy.contains("Pessoal").should("be.visible");
+					cy.contains("Exegese").should("be.visible");
+				});
+		});
+	});
 
-  it("falls back to the neutral 'Comentário' badge when there are no tags", () => {
-    getVerseId("gn", 1, 1).then((verseId) => {
-      cy.request("POST", `/api/comments/${verseId}`, {
-        text: "comentário sem categoria",
-        tags: [],
-      });
-      cy.visit("/verses/gn/1");
-      cy.get("li#1 button").first().click();
-      cy.contains("comentário sem categoria").should("be.visible");
-      cy.get('[data-testid="tag-badges"]')
-        .filter(':contains("Comentário")')
-        .should("exist");
-    });
-  });
+	it("falls back to the neutral 'Comentário' badge when there are no tags", () => {
+		getVerseId("gn", 1, 1).then((verseId) => {
+			cy.request("POST", `/api/comments/${verseId}`, {
+				text: "comentário sem categoria",
+				tags: [],
+			});
+			cy.visit("/verses/gn/1");
+			cy.get("li#1 button").first().click();
+			cy.contains("comentário sem categoria").should("be.visible");
+			cy.get('[data-testid="tag-badges"]')
+				.filter(':contains("Comentário")')
+				.should("exist");
+		});
+	});
 
-  it("share button opens a preview modal; /c/<id> and OG image respond", () => {
-    getVerseId("gn", 1, 1).then((verseId) => {
-      cy.request("POST", `/api/comments/${verseId}`, {
-        text: "comentário para compartilhar",
-        tags: ["devocional"],
-      }).then((res) => {
-        const id = res.body._id as string;
+	it("share button opens a preview modal; /c/<id> and OG image respond", () => {
+		getVerseId("gn", 1, 1).then((verseId) => {
+			cy.request("POST", `/api/comments/${verseId}`, {
+				text: "comentário para compartilhar",
+				tags: ["devocional"],
+			}).then((res) => {
+				const id = res.body._id as string;
 
-        cy.visit("/verses/gn/1");
-        cy.get("li#1 button").first().click();
-        cy.contains("comentário para compartilhar").should("be.visible");
+				cy.visit("/verses/gn/1");
+				cy.get("li#1 button").first().click();
+				cy.contains("comentário para compartilhar").should("be.visible");
 
-        cy.get('[aria-label="Compartilhar comentário"]').first().click();
-        cy.get('[role="dialog"], [aria-label="Compartilhar comentário"]')
-          .should("exist");
-        cy.get('img[alt="Pré-visualização do card do comentário"]')
-          .should("have.attr", "src")
-          .and("include", `/api/og/comment/${id}`);
+				cy.get('[aria-label="Compartilhar comentário"]').first().click();
+				cy.get(
+					'[role="dialog"], [aria-label="Compartilhar comentário"]',
+				).should("exist");
+				cy.get('img[alt="Pré-visualização do card do comentário"]')
+					.should("have.attr", "src")
+					.and("include", `/api/og/comment/${id}`);
 
-        cy.request(`/api/og/comment/${id}`).then((r) => {
-          expect(r.status).to.eq(200);
-          expect(r.headers["content-type"]).to.include("image/png");
-        });
-        cy.request(`/c/${id}`).then((r) => {
-          expect(r.status).to.eq(200);
-        });
-      });
-    });
-  });
+				cy.request(`/api/og/comment/${id}`).then((r) => {
+					expect(r.status).to.eq(200);
+					expect(r.headers["content-type"]).to.include("image/png");
+				});
+				cy.request(`/c/${id}`).then((r) => {
+					expect(r.status).to.eq(200);
+				});
+			});
+		});
+	});
 });

--- a/nextjs/cypress/e2e/comments.cy.ts
+++ b/nextjs/cypress/e2e/comments.cy.ts
@@ -10,323 +10,345 @@ import users from "../fixtures/users.json";
 import bookFixture from "../fixtures/book-gn.json";
 
 function getVerseId(
-  abbrev: string,
-  chapter: number,
-  verseNumber: number,
+	abbrev: string,
+	chapter: number,
+	verseNumber: number,
 ): Cypress.Chainable<string> {
-  return cy.request("GET", `/api/books/${abbrev}/verses/${chapter}`).then((res) => {
-    const verse = (res.body as Array<{ _id: string; verseNumber: number }>).find(
-      (item) => item.verseNumber === verseNumber,
-    );
-    if (!verse) {
-      throw new Error(
-        `verse ${abbrev} ${chapter}:${verseNumber} should be seeded`,
-      );
-    }
-    return verse._id;
-  });
+	return cy
+		.request("GET", `/api/books/${abbrev}/verses/${chapter}`)
+		.then((res) => {
+			const verse = (
+				res.body as Array<{ _id: string; verseNumber: number }>
+			).find((item) => item.verseNumber === verseNumber);
+			if (!verse) {
+				throw new Error(
+					`verse ${abbrev} ${chapter}:${verseNumber} should be seeded`,
+				);
+			}
+			return verse._id;
+		});
 }
 
 describe("Comments — full lifecycle", () => {
-  beforeEach(() => {
-    cy.resetDb();
-    cy.seedDb({
-      // Seed the chapter tutorial as completed so its full-screen coach-mark
-      // overlay (pointer-events:none on the page) doesn't block the reader
-      // panel in the inline-delete UI tests. Harmless for the API tests.
-      users: [users.alice, users.bob, users.mod].map((u) => ({
-        ...u,
-        tutorialsCompleted: ["chapter-v1"],
-      })),
-      books: [bookFixture.book],
-      verses: bookFixture.verses,
-    });
-  });
+	beforeEach(() => {
+		cy.resetDb();
+		cy.seedDb({
+			// Seed the chapter tutorial as completed so its full-screen coach-mark
+			// overlay (pointer-events:none on the page) doesn't block the reader
+			// panel in the inline-delete UI tests. Harmless for the API tests.
+			users: [users.alice, users.bob, users.mod].map((u) => ({
+				...u,
+				tutorialsCompleted: ["chapter-v1"],
+			})),
+			books: [bookFixture.book],
+			verses: bookFixture.verses,
+		});
+	});
 
-  describe("Create", () => {
-    it("authenticated user posts and the comment appears in the verse listing", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
+	describe("Create", () => {
+		it("authenticated user posts and the comment appears in the verse listing", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
 
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "Comentário de teste — alice em Gn 1:1", tags: ["devocional"] },
-        }).then((res) => {
-          expect(res.status).to.eq(201);
-          expect(res.body).to.have.property("username", "alice");
-          expect(res.body).to.have.property("text", "Comentário de teste — alice em Gn 1:1");
-        });
-      });
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: {
+						text: "Comentário de teste — alice em Gn 1:1",
+						tags: ["devocional"],
+					},
+				}).then((res) => {
+					expect(res.status).to.eq(201);
+					expect(res.body).to.have.property("username", "alice");
+					expect(res.body).to.have.property(
+						"text",
+						"Comentário de teste — alice em Gn 1:1",
+					);
+				});
+			});
 
-      cy.request("/api/comments/chapter/gn/1/1").then((res) => {
-        const all = [...(res.body.titleComments ?? []), ...(res.body.verseComments ?? [])];
-        const mine = all.find((c: { username: string }) => c.username === "alice");
-        expect(mine, "alice's comment should appear in the verse listing").to.exist;
-      });
-    });
+			cy.request("/api/comments/chapter/gn/1/1").then((res) => {
+				const all = [
+					...(res.body.titleComments ?? []),
+					...(res.body.verseComments ?? []),
+				];
+				const mine = all.find(
+					(c: { username: string }) => c.username === "alice",
+				);
+				expect(mine, "alice's comment should appear in the verse listing").to
+					.exist;
+			});
+		});
 
-    it("rejects anonymous POST with 401", () => {
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "should not land", tags: [] },
-          failOnStatusCode: false,
-        }).then((res) => {
-          expect(res.status).to.eq(401);
-        });
-      });
-    });
+		it("rejects anonymous POST with 401", () => {
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "should not land", tags: [] },
+					failOnStatusCode: false,
+				}).then((res) => {
+					expect(res.status).to.eq(401);
+				});
+			});
+		});
 
-    it("rejects empty text with 400 (Zod validation)", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "", tags: [] },
-          failOnStatusCode: false,
-        }).then((res) => {
-          expect(res.status).to.eq(400);
-          expect(res.body).to.have.property("error", "Validation failed");
-        });
-      });
-    });
-  });
+		it("rejects empty text with 400 (Zod validation)", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "", tags: [] },
+					failOnStatusCode: false,
+				}).then((res) => {
+					expect(res.status).to.eq(400);
+					expect(res.body).to.have.property("error", "Validation failed");
+				});
+			});
+		});
+	});
 
-  describe("Update (PATCH)", () => {
-    it("owner can edit their own comment text", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "first draft", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { text: "edited by alice", tags: ["pessoal"] },
-          }).then((patchRes) => {
-            expect(patchRes.status).to.eq(200);
-            expect(patchRes.body).to.have.property("text", "edited by alice");
-            expect(patchRes.body.tags).to.include("pessoal");
-          });
-        });
-      });
-    });
+	describe("Update (PATCH)", () => {
+		it("owner can edit their own comment text", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "first draft", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { text: "edited by alice", tags: ["pessoal"] },
+					}).then((patchRes) => {
+						expect(patchRes.status).to.eq(200);
+						expect(patchRes.body).to.have.property("text", "edited by alice");
+						expect(patchRes.body.tags).to.include("pessoal");
+					});
+				});
+			});
+		});
 
-    it("non-owner gets 403 when editing someone else's comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      let commentId: string;
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "alice's comment", tags: [] },
-        }).then((createRes) => {
-          commentId = createRes.body._id as string;
+		it("non-owner gets 403 when editing someone else's comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			let commentId: string;
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "alice's comment", tags: [] },
+				}).then((createRes) => {
+					commentId = createRes.body._id as string;
 
-          // Switch to bob and try to edit alice's comment.
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${commentId}`,
-            body: { text: "bob hijacking", tags: [] },
-            failOnStatusCode: false,
-          }).then((res) => {
-            expect(res.status).to.eq(403);
-          });
-        });
-      });
-    });
-  });
+					// Switch to bob and try to edit alice's comment.
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${commentId}`,
+						body: { text: "bob hijacking", tags: [] },
+						failOnStatusCode: false,
+					}).then((res) => {
+						expect(res.status).to.eq(403);
+					});
+				});
+			});
+		});
+	});
 
-  describe("Like / Report (PATCH with action)", () => {
-    it("toggle like flips the count + likedByMe via the CommentLike collection", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "likeable", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
+	describe("Like / Report (PATCH with action)", () => {
+		it("toggle like flips the count + likedByMe via the CommentLike collection", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "likeable", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
 
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "like" },
-          }).then((res) => {
-            expect(res.body.commentId).to.eq(id);
-            expect(res.body.likeCount).to.eq(1);
-            expect(res.body.likedByMe).to.eq(true);
-          });
-          cy.task<number>("db:countLikesForComment", id).should("eq", 1);
-          cy.task<number>("db:countCommentLikesByUser", users.bob.email).should("eq", 1);
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "like" },
+					}).then((res) => {
+						expect(res.body.commentId).to.eq(id);
+						expect(res.body.likeCount).to.eq(1);
+						expect(res.body.likedByMe).to.eq(true);
+					});
+					cy.task<number>("db:countLikesForComment", id).should("eq", 1);
+					cy.task<number>("db:countCommentLikesByUser", users.bob.email).should(
+						"eq",
+						1,
+					);
 
-          // Toggle off.
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "like" },
-          }).then((res) => {
-            expect(res.body.likeCount).to.eq(0);
-            expect(res.body.likedByMe).to.eq(false);
-          });
-          cy.task<number>("db:countLikesForComment", id).should("eq", 0);
-        });
-      });
-    });
+					// Toggle off.
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "like" },
+					}).then((res) => {
+						expect(res.body.likeCount).to.eq(0);
+						expect(res.body.likedByMe).to.eq(false);
+					});
+					cy.task<number>("db:countLikesForComment", id).should("eq", 0);
+				});
+			});
+		});
 
-    it("report inserts a CommentReport row and is idempotent on the unique index", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "reportable", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
+		it("report inserts a CommentReport row and is idempotent on the unique index", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "reportable", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
 
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "report" },
-          }).then((res) => {
-            expect(res.body.commentId).to.eq(id);
-            expect(res.body.reportCount).to.eq(1);
-            expect(res.body.reportedByMe).to.eq(true);
-          });
-          cy.task<number>("db:countReportsForComment", id).should("eq", 1);
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "report" },
+					}).then((res) => {
+						expect(res.body.commentId).to.eq(id);
+						expect(res.body.reportCount).to.eq(1);
+						expect(res.body.reportedByMe).to.eq(true);
+					});
+					cy.task<number>("db:countReportsForComment", id).should("eq", 1);
 
-          // Reporting again is a no-op (unique {userId, commentId} index).
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "report" },
-          }).then((res) => {
-            expect(res.body.reportCount, "report must be idempotent").to.eq(1);
-          });
-          cy.task<number>("db:countReportsForComment", id).should("eq", 1);
-        });
-      });
-    });
-  });
+					// Reporting again is a no-op (unique {userId, commentId} index).
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "report" },
+					}).then((res) => {
+						expect(res.body.reportCount, "report must be idempotent").to.eq(1);
+					});
+					cy.task<number>("db:countReportsForComment", id).should("eq", 1);
+				});
+			});
+		});
+	});
 
-  describe("Delete", () => {
-    it("owner can delete their own comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "to delete", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
-          cy.request({ method: "DELETE", url: `/api/comments/${id}` }).then((res) => {
-            expect(res.status).to.eq(200);
-            expect(res.body).to.have.property("success", true);
-          });
-        });
-      });
-    });
+	describe("Delete", () => {
+		it("owner can delete their own comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "to delete", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
+					cy.request({ method: "DELETE", url: `/api/comments/${id}` }).then(
+						(res) => {
+							expect(res.status).to.eq(200);
+							expect(res.body).to.have.property("success", true);
+						},
+					);
+				});
+			});
+		});
 
-    it("moderator can delete anyone's comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      let commentId: string;
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "alice's, mod will delete", tags: [] },
-        }).then((createRes) => {
-          commentId = createRes.body._id as string;
+		it("moderator can delete anyone's comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			let commentId: string;
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "alice's, mod will delete", tags: [] },
+				}).then((createRes) => {
+					commentId = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.mod.email, users.mod.password);
-          cy.request({ method: "DELETE", url: `/api/comments/${commentId}` }).then((res) => {
-            expect(res.status).to.eq(200);
-          });
-        });
-      });
-    });
+					cy.clearCookies();
+					cy.loginAs(users.mod.email, users.mod.password);
+					cy.request({
+						method: "DELETE",
+						url: `/api/comments/${commentId}`,
+					}).then((res) => {
+						expect(res.status).to.eq(200);
+					});
+				});
+			});
+		});
 
-    it("non-owner non-moderator gets 403", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      let commentId: string;
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "alice's", tags: [] },
-        }).then((createRes) => {
-          commentId = createRes.body._id as string;
+		it("non-owner non-moderator gets 403", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			let commentId: string;
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "alice's", tags: [] },
+				}).then((createRes) => {
+					commentId = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
-          cy.request({
-            method: "DELETE",
-            url: `/api/comments/${commentId}`,
-            failOnStatusCode: false,
-          }).then((res) => {
-            expect(res.status).to.eq(403);
-          });
-        });
-      });
-    });
-  });
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
+					cy.request({
+						method: "DELETE",
+						url: `/api/comments/${commentId}`,
+						failOnStatusCode: false,
+					}).then((res) => {
+						expect(res.status).to.eq(403);
+					});
+				});
+			});
+		});
+	});
 
-  describe("Inline delete (reader panel)", () => {
-    it("author can delete their own comment from the reader panel", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request("POST", `/api/comments/${verseId}`, {
-          text: "alice inline-delete target",
-          tags: ["devocional"],
-        }).then((res) => {
-          const id = res.body._id as string;
+	describe("Inline delete (reader panel)", () => {
+		it("author can delete their own comment from the reader panel", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request("POST", `/api/comments/${verseId}`, {
+					text: "alice inline-delete target",
+					tags: ["devocional"],
+				}).then((res) => {
+					const id = res.body._id as string;
 
-          cy.visit("/verses/gn/1");
-          cy.get("li#1 button").first().click();
-          cy.contains("alice inline-delete target").should("be.visible");
+					cy.visit("/verses/gn/1");
+					cy.get("li#1 button").first().click();
+					cy.contains("alice inline-delete target").should("be.visible");
 
-          cy.get(`[data-testid="delete-${id}"]`).click();
-          cy.get('[role="alertdialog"]').should("be.visible");
-          cy.get('[role="alertdialog"] button[data-variant="danger"]').click();
+					cy.get(`[data-testid="delete-${id}"]`).click();
+					cy.get('[role="alertdialog"]').should("be.visible");
+					cy.get('[role="alertdialog"] button[data-variant="danger"]').click();
 
-          cy.contains("alice inline-delete target").should("not.exist");
-        });
-      });
-    });
+					cy.contains("alice inline-delete target").should("not.exist");
+				});
+			});
+		});
 
-    it("non-author does not see the delete button on someone else's comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request("POST", `/api/comments/${verseId}`, {
-          text: "alice owns this one",
-          tags: ["devocional"],
-        }).then((res) => {
-          const id = res.body._id as string;
+		it("non-author does not see the delete button on someone else's comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request("POST", `/api/comments/${verseId}`, {
+					text: "alice owns this one",
+					tags: ["devocional"],
+				}).then((res) => {
+					const id = res.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
-          cy.visit("/verses/gn/1");
-          cy.get("li#1 button").first().click();
-          cy.contains("alice owns this one").should("be.visible");
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
+					cy.visit("/verses/gn/1");
+					cy.get("li#1 button").first().click();
+					cy.contains("alice owns this one").should("be.visible");
 
-          cy.get(`[data-testid="delete-${id}"]`).should("not.exist");
-        });
-      });
-    });
-  });
+					cy.get(`[data-testid="delete-${id}"]`).should("not.exist");
+				});
+			});
+		});
+	});
 });

--- a/nextjs/cypress/e2e/comments.cy.ts
+++ b/nextjs/cypress/e2e/comments.cy.ts
@@ -351,4 +351,35 @@ describe("Comments — full lifecycle", () => {
 			});
 		});
 	});
+
+	// Regression: in a standalone PWA the Android back gesture maps to
+	// history.back(). The panel used to be pure React state with no
+	// history entry, so back navigated away from the chapter (and EXITED
+	// the app when it was the first history entry) instead of just
+	// closing the comment panel.
+	describe("Back gesture closes the comment panel (PWA)", () => {
+		it("browser/Android back closes the panel and stays on the chapter", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			cy.visit("/verses/gn/1");
+			cy.get("li#1 button").first().click();
+			cy.get('[aria-label="Fechar comentários"]').should("be.visible");
+
+			cy.go("back");
+
+			cy.location("pathname").should("eq", "/verses/gn/1");
+			cy.get('[aria-label="Fechar comentários"]').should("not.exist");
+		});
+
+		it("closing with the X button still works and stays on the chapter", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			cy.visit("/verses/gn/1");
+			cy.get("li#1 button").first().click();
+			cy.get('[aria-label="Fechar comentários"]').should("be.visible");
+
+			cy.get('[aria-label="Fechar comentários"]').click();
+
+			cy.location("pathname").should("eq", "/verses/gn/1");
+			cy.get('[aria-label="Fechar comentários"]').should("not.exist");
+		});
+	});
 });

--- a/nextjs/cypress/e2e/comments.cy.ts
+++ b/nextjs/cypress/e2e/comments.cy.ts
@@ -275,4 +275,48 @@ describe("Comments — full lifecycle", () => {
       });
     });
   });
+
+  describe("Inline delete (reader panel)", () => {
+    it("author can delete their own comment from the reader panel", () => {
+      cy.loginAs(users.alice.email, users.alice.password);
+      getVerseId("gn", 1, 1).then((verseId) => {
+        cy.request("POST", `/api/comments/${verseId}`, {
+          text: "alice inline-delete target",
+          tags: ["devocional"],
+        }).then((res) => {
+          const id = res.body._id as string;
+
+          cy.visit("/verses/gn/1");
+          cy.get("li#1 button").first().click();
+          cy.contains("alice inline-delete target").should("be.visible");
+
+          cy.get(`[data-testid="delete-${id}"]`).click();
+          cy.get('[role="alertdialog"]').should("be.visible");
+          cy.get('[role="alertdialog"] button[data-variant="danger"]').click();
+
+          cy.contains("alice inline-delete target").should("not.exist");
+        });
+      });
+    });
+
+    it("non-author does not see the delete button on someone else's comment", () => {
+      cy.loginAs(users.alice.email, users.alice.password);
+      getVerseId("gn", 1, 1).then((verseId) => {
+        cy.request("POST", `/api/comments/${verseId}`, {
+          text: "alice owns this one",
+          tags: ["devocional"],
+        }).then((res) => {
+          const id = res.body._id as string;
+
+          cy.clearCookies();
+          cy.loginAs(users.bob.email, users.bob.password);
+          cy.visit("/verses/gn/1");
+          cy.get("li#1 button").first().click();
+          cy.contains("alice owns this one").should("be.visible");
+
+          cy.get(`[data-testid="delete-${id}"]`).should("not.exist");
+        });
+      });
+    });
+  });
 });

--- a/nextjs/cypress/e2e/comments.cy.ts
+++ b/nextjs/cypress/e2e/comments.cy.ts
@@ -10,313 +10,338 @@ import users from "../fixtures/users.json";
 import bookFixture from "../fixtures/book-gn.json";
 
 function getVerseId(
-  abbrev: string,
-  chapter: number,
-  verseNumber: number,
+	abbrev: string,
+	chapter: number,
+	verseNumber: number,
 ): Cypress.Chainable<string> {
-  return cy.request("GET", `/api/books/${abbrev}/verses/${chapter}`).then((res) => {
-    const verse = (res.body as Array<{ _id: string; verseNumber: number }>).find(
-      (v) => v.verseNumber === verseNumber,
-    );
-    expect(verse, `verse ${abbrev} ${chapter}:${verseNumber} should be seeded`).to.exist;
-    return verse!._id;
-  });
+	return cy
+		.request("GET", `/api/books/${abbrev}/verses/${chapter}`)
+		.then((res) => {
+			const verse = (
+				res.body as Array<{ _id: string; verseNumber: number }>
+			).find((v) => v.verseNumber === verseNumber);
+			expect(
+				verse,
+				`verse ${abbrev} ${chapter}:${verseNumber} should be seeded`,
+			).to.exist;
+			return verse!._id;
+		});
 }
 
 describe("Comments — full lifecycle", () => {
-  beforeEach(() => {
-    cy.resetDb();
-    cy.seedDb({
-      users: [users.alice, users.bob, users.mod],
-      books: [bookFixture.book],
-      verses: bookFixture.verses,
-    });
-  });
+	beforeEach(() => {
+		cy.resetDb();
+		cy.seedDb({
+			users: [users.alice, users.bob, users.mod],
+			books: [bookFixture.book],
+			verses: bookFixture.verses,
+		});
+	});
 
-  describe("Create", () => {
-    it("authenticated user posts and the comment appears in the verse listing", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
+	describe("Create", () => {
+		it("authenticated user posts and the comment appears in the verse listing", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
 
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "Comentário de teste — alice em Gn 1:1", tags: ["devocional"] },
-        }).then((res) => {
-          expect(res.status).to.eq(201);
-          expect(res.body).to.have.property("username", "alice");
-          expect(res.body).to.have.property("text", "Comentário de teste — alice em Gn 1:1");
-        });
-      });
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: {
+						text: "Comentário de teste — alice em Gn 1:1",
+						tags: ["devocional"],
+					},
+				}).then((res) => {
+					expect(res.status).to.eq(201);
+					expect(res.body).to.have.property("username", "alice");
+					expect(res.body).to.have.property(
+						"text",
+						"Comentário de teste — alice em Gn 1:1",
+					);
+				});
+			});
 
-      cy.request("/api/comments/chapter/gn/1/1").then((res) => {
-        const all = [...(res.body.titleComments ?? []), ...(res.body.verseComments ?? [])];
-        const mine = all.find((c: { username: string }) => c.username === "alice");
-        expect(mine, "alice's comment should appear in the verse listing").to.exist;
-      });
-    });
+			cy.request("/api/comments/chapter/gn/1/1").then((res) => {
+				const all = [
+					...(res.body.titleComments ?? []),
+					...(res.body.verseComments ?? []),
+				];
+				const mine = all.find(
+					(c: { username: string }) => c.username === "alice",
+				);
+				expect(mine, "alice's comment should appear in the verse listing").to
+					.exist;
+			});
+		});
 
-    it("rejects anonymous POST with 401", () => {
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "should not land", tags: [] },
-          failOnStatusCode: false,
-        }).then((res) => {
-          expect(res.status).to.eq(401);
-        });
-      });
-    });
+		it("rejects anonymous POST with 401", () => {
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "should not land", tags: [] },
+					failOnStatusCode: false,
+				}).then((res) => {
+					expect(res.status).to.eq(401);
+				});
+			});
+		});
 
-    it("rejects empty text with 400 (Zod validation)", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "", tags: [] },
-          failOnStatusCode: false,
-        }).then((res) => {
-          expect(res.status).to.eq(400);
-          expect(res.body).to.have.property("error", "Validation failed");
-        });
-      });
-    });
-  });
+		it("rejects empty text with 400 (Zod validation)", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "", tags: [] },
+					failOnStatusCode: false,
+				}).then((res) => {
+					expect(res.status).to.eq(400);
+					expect(res.body).to.have.property("error", "Validation failed");
+				});
+			});
+		});
+	});
 
-  describe("Update (PATCH)", () => {
-    it("owner can edit their own comment text", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "first draft", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { text: "edited by alice", tags: ["pessoal"] },
-          }).then((patchRes) => {
-            expect(patchRes.status).to.eq(200);
-            expect(patchRes.body).to.have.property("text", "edited by alice");
-            expect(patchRes.body.tags).to.include("pessoal");
-          });
-        });
-      });
-    });
+	describe("Update (PATCH)", () => {
+		it("owner can edit their own comment text", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "first draft", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { text: "edited by alice", tags: ["pessoal"] },
+					}).then((patchRes) => {
+						expect(patchRes.status).to.eq(200);
+						expect(patchRes.body).to.have.property("text", "edited by alice");
+						expect(patchRes.body.tags).to.include("pessoal");
+					});
+				});
+			});
+		});
 
-    it("non-owner gets 403 when editing someone else's comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      let commentId: string;
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "alice's comment", tags: [] },
-        }).then((createRes) => {
-          commentId = createRes.body._id as string;
+		it("non-owner gets 403 when editing someone else's comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			let commentId: string;
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "alice's comment", tags: [] },
+				}).then((createRes) => {
+					commentId = createRes.body._id as string;
 
-          // Switch to bob and try to edit alice's comment.
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${commentId}`,
-            body: { text: "bob hijacking", tags: [] },
-            failOnStatusCode: false,
-          }).then((res) => {
-            expect(res.status).to.eq(403);
-          });
-        });
-      });
-    });
-  });
+					// Switch to bob and try to edit alice's comment.
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${commentId}`,
+						body: { text: "bob hijacking", tags: [] },
+						failOnStatusCode: false,
+					}).then((res) => {
+						expect(res.status).to.eq(403);
+					});
+				});
+			});
+		});
+	});
 
-  describe("Like / Report (PATCH with action)", () => {
-    it("toggle like flips the count + likedByMe via the CommentLike collection", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "likeable", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
+	describe("Like / Report (PATCH with action)", () => {
+		it("toggle like flips the count + likedByMe via the CommentLike collection", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "likeable", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
 
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "like" },
-          }).then((res) => {
-            expect(res.body.commentId).to.eq(id);
-            expect(res.body.likeCount).to.eq(1);
-            expect(res.body.likedByMe).to.eq(true);
-          });
-          cy.task<number>("db:countLikesForComment", id).should("eq", 1);
-          cy.task<number>("db:countCommentLikesByUser", users.bob.email).should("eq", 1);
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "like" },
+					}).then((res) => {
+						expect(res.body.commentId).to.eq(id);
+						expect(res.body.likeCount).to.eq(1);
+						expect(res.body.likedByMe).to.eq(true);
+					});
+					cy.task<number>("db:countLikesForComment", id).should("eq", 1);
+					cy.task<number>("db:countCommentLikesByUser", users.bob.email).should(
+						"eq",
+						1,
+					);
 
-          // Toggle off.
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "like" },
-          }).then((res) => {
-            expect(res.body.likeCount).to.eq(0);
-            expect(res.body.likedByMe).to.eq(false);
-          });
-          cy.task<number>("db:countLikesForComment", id).should("eq", 0);
-        });
-      });
-    });
+					// Toggle off.
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "like" },
+					}).then((res) => {
+						expect(res.body.likeCount).to.eq(0);
+						expect(res.body.likedByMe).to.eq(false);
+					});
+					cy.task<number>("db:countLikesForComment", id).should("eq", 0);
+				});
+			});
+		});
 
-    it("report inserts a CommentReport row and is idempotent on the unique index", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "reportable", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
+		it("report inserts a CommentReport row and is idempotent on the unique index", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "reportable", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
 
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "report" },
-          }).then((res) => {
-            expect(res.body.commentId).to.eq(id);
-            expect(res.body.reportCount).to.eq(1);
-            expect(res.body.reportedByMe).to.eq(true);
-          });
-          cy.task<number>("db:countReportsForComment", id).should("eq", 1);
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "report" },
+					}).then((res) => {
+						expect(res.body.commentId).to.eq(id);
+						expect(res.body.reportCount).to.eq(1);
+						expect(res.body.reportedByMe).to.eq(true);
+					});
+					cy.task<number>("db:countReportsForComment", id).should("eq", 1);
 
-          // Reporting again is a no-op (unique {userId, commentId} index).
-          cy.request({
-            method: "PATCH",
-            url: `/api/comments/${id}`,
-            body: { action: "report" },
-          }).then((res) => {
-            expect(res.body.reportCount, "report must be idempotent").to.eq(1);
-          });
-          cy.task<number>("db:countReportsForComment", id).should("eq", 1);
-        });
-      });
-    });
-  });
+					// Reporting again is a no-op (unique {userId, commentId} index).
+					cy.request({
+						method: "PATCH",
+						url: `/api/comments/${id}`,
+						body: { action: "report" },
+					}).then((res) => {
+						expect(res.body.reportCount, "report must be idempotent").to.eq(1);
+					});
+					cy.task<number>("db:countReportsForComment", id).should("eq", 1);
+				});
+			});
+		});
+	});
 
-  describe("Delete", () => {
-    it("owner can delete their own comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "to delete", tags: [] },
-        }).then((createRes) => {
-          const id = createRes.body._id as string;
-          cy.request({ method: "DELETE", url: `/api/comments/${id}` }).then((res) => {
-            expect(res.status).to.eq(200);
-            expect(res.body).to.have.property("success", true);
-          });
-        });
-      });
-    });
+	describe("Delete", () => {
+		it("owner can delete their own comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "to delete", tags: [] },
+				}).then((createRes) => {
+					const id = createRes.body._id as string;
+					cy.request({ method: "DELETE", url: `/api/comments/${id}` }).then(
+						(res) => {
+							expect(res.status).to.eq(200);
+							expect(res.body).to.have.property("success", true);
+						},
+					);
+				});
+			});
+		});
 
-    it("moderator can delete anyone's comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      let commentId: string;
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "alice's, mod will delete", tags: [] },
-        }).then((createRes) => {
-          commentId = createRes.body._id as string;
+		it("moderator can delete anyone's comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			let commentId: string;
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "alice's, mod will delete", tags: [] },
+				}).then((createRes) => {
+					commentId = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.mod.email, users.mod.password);
-          cy.request({ method: "DELETE", url: `/api/comments/${commentId}` }).then((res) => {
-            expect(res.status).to.eq(200);
-          });
-        });
-      });
-    });
+					cy.clearCookies();
+					cy.loginAs(users.mod.email, users.mod.password);
+					cy.request({
+						method: "DELETE",
+						url: `/api/comments/${commentId}`,
+					}).then((res) => {
+						expect(res.status).to.eq(200);
+					});
+				});
+			});
+		});
 
-    it("non-owner non-moderator gets 403", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      let commentId: string;
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request({
-          method: "POST",
-          url: `/api/comments/${verseId}`,
-          body: { text: "alice's", tags: [] },
-        }).then((createRes) => {
-          commentId = createRes.body._id as string;
+		it("non-owner non-moderator gets 403", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			let commentId: string;
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request({
+					method: "POST",
+					url: `/api/comments/${verseId}`,
+					body: { text: "alice's", tags: [] },
+				}).then((createRes) => {
+					commentId = createRes.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
-          cy.request({
-            method: "DELETE",
-            url: `/api/comments/${commentId}`,
-            failOnStatusCode: false,
-          }).then((res) => {
-            expect(res.status).to.eq(403);
-          });
-        });
-      });
-    });
-  });
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
+					cy.request({
+						method: "DELETE",
+						url: `/api/comments/${commentId}`,
+						failOnStatusCode: false,
+					}).then((res) => {
+						expect(res.status).to.eq(403);
+					});
+				});
+			});
+		});
+	});
 
-  describe("Inline delete (reader panel)", () => {
-    it("author can delete their own comment from the reader panel", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request("POST", `/api/comments/${verseId}`, {
-          text: "alice inline-delete target",
-          tags: ["devocional"],
-        }).then((res) => {
-          const id = res.body._id as string;
+	describe("Inline delete (reader panel)", () => {
+		it("author can delete their own comment from the reader panel", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request("POST", `/api/comments/${verseId}`, {
+					text: "alice inline-delete target",
+					tags: ["devocional"],
+				}).then((res) => {
+					const id = res.body._id as string;
 
-          cy.visit("/verses/gn/1");
-          cy.get("li#1 button").first().click();
-          cy.contains("alice inline-delete target").should("be.visible");
+					cy.visit("/verses/gn/1");
+					cy.get("li#1 button").first().click();
+					cy.contains("alice inline-delete target").should("be.visible");
 
-          cy.get(`[data-testid="delete-${id}"]`).click();
-          cy.get('[role="alertdialog"]').should("be.visible");
-          cy.get('[role="alertdialog"] button[data-variant="danger"]').click();
+					cy.get(`[data-testid="delete-${id}"]`).click();
+					cy.get('[role="alertdialog"]').should("be.visible");
+					cy.get('[role="alertdialog"] button[data-variant="danger"]').click();
 
-          cy.contains("alice inline-delete target").should("not.exist");
-        });
-      });
-    });
+					cy.contains("alice inline-delete target").should("not.exist");
+				});
+			});
+		});
 
-    it("non-author does not see the delete button on someone else's comment", () => {
-      cy.loginAs(users.alice.email, users.alice.password);
-      getVerseId("gn", 1, 1).then((verseId) => {
-        cy.request("POST", `/api/comments/${verseId}`, {
-          text: "alice owns this one",
-          tags: ["devocional"],
-        }).then((res) => {
-          const id = res.body._id as string;
+		it("non-author does not see the delete button on someone else's comment", () => {
+			cy.loginAs(users.alice.email, users.alice.password);
+			getVerseId("gn", 1, 1).then((verseId) => {
+				cy.request("POST", `/api/comments/${verseId}`, {
+					text: "alice owns this one",
+					tags: ["devocional"],
+				}).then((res) => {
+					const id = res.body._id as string;
 
-          cy.clearCookies();
-          cy.loginAs(users.bob.email, users.bob.password);
-          cy.visit("/verses/gn/1");
-          cy.get("li#1 button").first().click();
-          cy.contains("alice owns this one").should("be.visible");
+					cy.clearCookies();
+					cy.loginAs(users.bob.email, users.bob.password);
+					cy.visit("/verses/gn/1");
+					cy.get("li#1 button").first().click();
+					cy.contains("alice owns this one").should("be.visible");
 
-          cy.get(`[data-testid="delete-${id}"]`).should("not.exist");
-        });
-      });
-    });
-  });
+					cy.get(`[data-testid="delete-${id}"]`).should("not.exist");
+				});
+			});
+		});
+	});
 });

--- a/nextjs/cypress/e2e/comments.cy.ts
+++ b/nextjs/cypress/e2e/comments.cy.ts
@@ -16,10 +16,14 @@ function getVerseId(
 ): Cypress.Chainable<string> {
   return cy.request("GET", `/api/books/${abbrev}/verses/${chapter}`).then((res) => {
     const verse = (res.body as Array<{ _id: string; verseNumber: number }>).find(
-      (v) => v.verseNumber === verseNumber,
+      (item) => item.verseNumber === verseNumber,
     );
-    expect(verse, `verse ${abbrev} ${chapter}:${verseNumber} should be seeded`).to.exist;
-    return verse!._id;
+    if (!verse) {
+      throw new Error(
+        `verse ${abbrev} ${chapter}:${verseNumber} should be seeded`,
+      );
+    }
+    return verse._id;
   });
 }
 
@@ -27,7 +31,13 @@ describe("Comments — full lifecycle", () => {
   beforeEach(() => {
     cy.resetDb();
     cy.seedDb({
-      users: [users.alice, users.bob, users.mod],
+      // Seed the chapter tutorial as completed so its full-screen coach-mark
+      // overlay (pointer-events:none on the page) doesn't block the reader
+      // panel in the inline-delete UI tests. Harmless for the API tests.
+      users: [users.alice, users.bob, users.mod].map((u) => ({
+        ...u,
+        tutorialsCompleted: ["chapter-v1"],
+      })),
       books: [bookFixture.book],
       verses: bookFixture.verses,
     });

--- a/nextjs/scripts/dev-with-mongo.js
+++ b/nextjs/scripts/dev-with-mongo.js
@@ -55,6 +55,17 @@ const FIXTURES = {
     { abbrev: "gn", chapter: 1, verseNumber: 2, text: "A terra era sem forma e vazia; havia trevas sobre a face do abismo.",          reference: "Gn 1:2" },
     { abbrev: "gn", chapter: 1, verseNumber: 3, text: "Disse Deus: Haja luz; e houve luz.",                                            reference: "Gn 1:3" },
   ],
+  // Demo comments on Gn 1:1 so the multi-category badges + share card +
+  // inline delete are actually visible when browsing (the API/Cypress
+  // path seeds none). verseNumber is resolved to the inserted verse _id
+  // in seed(). likeCount is derived from the CommentLike collection, so
+  // these show "0 Perspectivas" — enough to inspect the footer layout.
+  comments: [
+    { verseNumber: 1, username: "alice", tags: ["exegese", "pessoal"],                text: "Comentário multi-categoria: 'bara' (criar) aqui implica criação do nada — e me faz lembrar que minha própria história também começou do nada nas mãos de Deus." },
+    { verseNumber: 1, username: "bob",   tags: ["inspirado", "devocional", "pessoal"], text: "Três perspectivas num só: o Espírito me inspirou a ver beleza no caos, devocionalmente isso me acalma, e pessoalmente reorganiza meu dia." },
+    { verseNumber: 1, username: "alice", tags: ["devocional"],                         text: "Comentário de categoria única — começar o dia lembrando que tudo tem uma origem boa." },
+    { verseNumber: 1, username: "bob",   tags: [],                                     text: "Comentário sem categoria nenhuma — deve cair no badge neutro 'Comentário'." },
+  ],
 };
 
 const COLLECTIONS = [
@@ -96,10 +107,28 @@ async function seed(uri) {
   await db.collection("users").insertMany(userDocs);
 
   await db.collection("books").insertOne(FIXTURES.book);
-  await db.collection("verses").insertMany(FIXTURES.verses);
+  const { insertedIds } = await db.collection("verses").insertMany(FIXTURES.verses);
+
+  // Map verseNumber -> inserted _id so demo comments can reference it.
+  const verseIdByNumber = new Map(
+    FIXTURES.verses.map((v, i) => [v.verseNumber, insertedIds[i]]),
+  );
+  const now = new Date();
+  const commentDocs = FIXTURES.comments.map((c) => ({
+    verseId: verseIdByNumber.get(c.verseNumber),
+    username: c.username,
+    onTitle: false,
+    bookReference: `Gn 1:${c.verseNumber}`,
+    text: c.text,
+    tags: c.tags,
+    verified: false,
+    createdAt: now,
+    updatedAt: now,
+  }));
+  await db.collection("comments").insertMany(commentDocs);
 
   console.log(
-    `[dev] seeded ${FIXTURES.users.length} users (alice/bob/mod), 1 book (gn), ${FIXTURES.verses.length} verses`,
+    `[dev] seeded ${FIXTURES.users.length} users (alice/bob/mod), 1 book (gn), ${FIXTURES.verses.length} verses, ${commentDocs.length} demo comments on Gn 1:1`,
   );
   await mongoose.disconnect();
 }

--- a/nextjs/scripts/dev-with-mongo.js
+++ b/nextjs/scripts/dev-with-mongo.js
@@ -25,169 +25,242 @@ const bcrypt = require("bcryptjs");
 const { assertLocalMongoUri } = require("./safety");
 
 if (process.env.MONGODB_URI) {
-  try {
-    assertLocalMongoUri(process.env.MONGODB_URI, "dev-with-mongo pre-flight");
-  } catch (err) {
-    console.error(`[dev] aborting: ${err.message}`);
-    process.exit(1);
-  }
-  console.warn(
-    "[dev] note: MONGODB_URI was already set in env — that value will be overridden by the in-memory server.",
-  );
+	try {
+		assertLocalMongoUri(process.env.MONGODB_URI, "dev-with-mongo pre-flight");
+	} catch (err) {
+		console.error(`[dev] aborting: ${err.message}`);
+		process.exit(1);
+	}
+	console.warn(
+		"[dev] note: MONGODB_URI was already set in env — that value will be overridden by the in-memory server.",
+	);
 }
 
 const FIXTURES = {
-  users: [
-    { email: "alice@cypress.test", username: "alice", password: "alice-secret-123", moderator: false },
-    { email: "bob@cypress.test",   username: "bob",   password: "bob-secret-123",   moderator: false },
-    { email: "mod@cypress.test",   username: "mod",   password: "mod-secret-123",   moderator: true  },
-  ],
-  book: {
-    abbrev: "gn",
-    name: "Gênesis",
-    chapters: 50,
-    testament: "VT",
-    group: "Pentateuco",
-    author: "Moisés",
-  },
-  verses: [
-    { abbrev: "gn", chapter: 1, verseNumber: 1, text: "No princípio, Deus criou os céus e a terra.",                                  reference: "Gn 1:1" },
-    { abbrev: "gn", chapter: 1, verseNumber: 2, text: "A terra era sem forma e vazia; havia trevas sobre a face do abismo.",          reference: "Gn 1:2" },
-    { abbrev: "gn", chapter: 1, verseNumber: 3, text: "Disse Deus: Haja luz; e houve luz.",                                            reference: "Gn 1:3" },
-  ],
-  // Demo comments on Gn 1:1 so the multi-category badges + share card +
-  // inline delete are actually visible when browsing (the API/Cypress
-  // path seeds none). verseNumber is resolved to the inserted verse _id
-  // in seed(). likeCount is derived from the CommentLike collection, so
-  // these show "0 Perspectivas" — enough to inspect the footer layout.
-  comments: [
-    { verseNumber: 1, username: "alice", tags: ["exegese", "pessoal"],                text: "Comentário multi-categoria: 'bara' (criar) aqui implica criação do nada — e me faz lembrar que minha própria história também começou do nada nas mãos de Deus." },
-    { verseNumber: 1, username: "bob",   tags: ["inspirado", "devocional", "pessoal"], text: "Três perspectivas num só: o Espírito me inspirou a ver beleza no caos, devocionalmente isso me acalma, e pessoalmente reorganiza meu dia." },
-    { verseNumber: 1, username: "alice", tags: ["devocional"],                         text: "Comentário de categoria única — começar o dia lembrando que tudo tem uma origem boa." },
-    { verseNumber: 1, username: "bob",   tags: [],                                     text: "Comentário sem categoria nenhuma — deve cair no badge neutro 'Comentário'." },
-  ],
+	users: [
+		{
+			email: "alice@cypress.test",
+			username: "alice",
+			password: "alice-secret-123",
+			moderator: false,
+		},
+		{
+			email: "bob@cypress.test",
+			username: "bob",
+			password: "bob-secret-123",
+			moderator: false,
+		},
+		{
+			email: "mod@cypress.test",
+			username: "mod",
+			password: "mod-secret-123",
+			moderator: true,
+		},
+	],
+	book: {
+		abbrev: "gn",
+		name: "Gênesis",
+		chapters: 50,
+		testament: "VT",
+		group: "Pentateuco",
+		author: "Moisés",
+	},
+	verses: [
+		{
+			abbrev: "gn",
+			chapter: 1,
+			verseNumber: 1,
+			text: "No princípio, Deus criou os céus e a terra.",
+			reference: "Gn 1:1",
+		},
+		{
+			abbrev: "gn",
+			chapter: 1,
+			verseNumber: 2,
+			text: "A terra era sem forma e vazia; havia trevas sobre a face do abismo.",
+			reference: "Gn 1:2",
+		},
+		{
+			abbrev: "gn",
+			chapter: 1,
+			verseNumber: 3,
+			text: "Disse Deus: Haja luz; e houve luz.",
+			reference: "Gn 1:3",
+		},
+	],
+	// Demo comments on Gn 1:1 so the multi-category badges + share card +
+	// inline delete are actually visible when browsing (the API/Cypress
+	// path seeds none). verseNumber is resolved to the inserted verse _id
+	// in seed(). likeCount is derived from the CommentLike collection, so
+	// these show "0 Perspectivas" — enough to inspect the footer layout.
+	comments: [
+		{
+			verseNumber: 1,
+			username: "alice",
+			tags: ["exegese", "pessoal"],
+			text: "Comentário multi-categoria: 'bara' (criar) aqui implica criação do nada — e me faz lembrar que minha própria história também começou do nada nas mãos de Deus.",
+		},
+		{
+			verseNumber: 1,
+			username: "bob",
+			tags: ["inspirado", "devocional", "pessoal"],
+			text: "Três perspectivas num só: o Espírito me inspirou a ver beleza no caos, devocionalmente isso me acalma, e pessoalmente reorganiza meu dia.",
+		},
+		{
+			verseNumber: 1,
+			username: "alice",
+			tags: ["devocional"],
+			text: "Comentário de categoria única — começar o dia lembrando que tudo tem uma origem boa.",
+		},
+		{
+			verseNumber: 1,
+			username: "bob",
+			tags: [],
+			text: "Comentário sem categoria nenhuma — deve cair no badge neutro 'Comentário'.",
+		},
+	],
 };
 
 const COLLECTIONS = [
-  "users",
-  "books",
-  "verses",
-  "comments",
-  "commentlikes",
-  "commentreports",
-  "discussions",
-  "discussionanswers",
-  "notifications",
-  "passwordresettokens",
-  "userchapterreads",
+	"users",
+	"books",
+	"verses",
+	"comments",
+	"commentlikes",
+	"commentreports",
+	"discussions",
+	"discussionanswers",
+	"notifications",
+	"passwordresettokens",
+	"userchapterreads",
 ];
 
 async function seed(uri) {
-  mongoose.set("strictQuery", false);
-  await mongoose.connect(uri);
-  const db = mongoose.connection.db;
-  if (!db) throw new Error("Mongoose has no db handle.");
+	mongoose.set("strictQuery", false);
+	await mongoose.connect(uri);
+	const db = mongoose.connection.db;
+	if (!db) throw new Error("Mongoose has no db handle.");
 
-  for (const name of COLLECTIONS) {
-    try { await db.collection(name).deleteMany({}); } catch { /* collection may not exist yet */ }
-  }
+	for (const name of COLLECTIONS) {
+		try {
+			await db.collection(name).deleteMany({});
+		} catch {
+			/* collection may not exist yet */
+		}
+	}
 
-  const userDocs = await Promise.all(
-    FIXTURES.users.map(async (u) => ({
-      email: u.email.toLowerCase().trim(),
-      username: u.username,
-      password: await bcrypt.hash(u.password, 12),
-      state: "",
-      belief: "",
-      moderator: u.moderator,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    })),
-  );
-  await db.collection("users").insertMany(userDocs);
+	const userDocs = await Promise.all(
+		FIXTURES.users.map(async (u) => ({
+			email: u.email.toLowerCase().trim(),
+			username: u.username,
+			password: await bcrypt.hash(u.password, 12),
+			state: "",
+			belief: "",
+			moderator: u.moderator,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		})),
+	);
+	await db.collection("users").insertMany(userDocs);
 
-  await db.collection("books").insertOne(FIXTURES.book);
-  const { insertedIds } = await db.collection("verses").insertMany(FIXTURES.verses);
+	await db.collection("books").insertOne(FIXTURES.book);
+	const { insertedIds } = await db
+		.collection("verses")
+		.insertMany(FIXTURES.verses);
 
-  // Map verseNumber -> inserted _id so demo comments can reference it.
-  const verseIdByNumber = new Map(
-    FIXTURES.verses.map((v, i) => [v.verseNumber, insertedIds[i]]),
-  );
-  const now = new Date();
-  const commentDocs = FIXTURES.comments.map((c) => ({
-    verseId: verseIdByNumber.get(c.verseNumber),
-    username: c.username,
-    onTitle: false,
-    bookReference: `Gn 1:${c.verseNumber}`,
-    text: c.text,
-    tags: c.tags,
-    verified: false,
-    createdAt: now,
-    updatedAt: now,
-  }));
-  await db.collection("comments").insertMany(commentDocs);
+	// Map verseNumber -> inserted _id so demo comments can reference it.
+	const verseIdByNumber = new Map(
+		FIXTURES.verses.map((v, i) => [v.verseNumber, insertedIds[i]]),
+	);
+	const now = new Date();
+	const commentDocs = FIXTURES.comments.map((c) => ({
+		verseId: verseIdByNumber.get(c.verseNumber),
+		username: c.username,
+		onTitle: false,
+		bookReference: `Gn 1:${c.verseNumber}`,
+		text: c.text,
+		tags: c.tags,
+		verified: false,
+		createdAt: now,
+		updatedAt: now,
+	}));
+	await db.collection("comments").insertMany(commentDocs);
 
-  console.log(
-    `[dev] seeded ${FIXTURES.users.length} users (alice/bob/mod), 1 book (gn), ${FIXTURES.verses.length} verses, ${commentDocs.length} demo comments on Gn 1:1`,
-  );
-  await mongoose.disconnect();
+	console.log(
+		`[dev] seeded ${FIXTURES.users.length} users (alice/bob/mod), 1 book (gn), ${FIXTURES.verses.length} verses, ${commentDocs.length} demo comments on Gn 1:1`,
+	);
+	await mongoose.disconnect();
 }
 
 async function main() {
-  console.log("[dev] starting mongodb-memory-server...");
-  const mongo = await MongoMemoryServer.create({
-    instance: { dbName: "biblecomment-dev" },
-  });
-  const uri = mongo.getUri();
-  // Sanity-check the in-memory URI is local. Defends against any future
-  // mongodb-memory-server change that might emit a non-localhost address.
-  assertLocalMongoUri(uri, "dev-with-mongo in-memory mongo");
-  console.log(`[dev] mongo ready at ${uri}`);
+	console.log("[dev] starting mongodb-memory-server...");
+	const mongo = await MongoMemoryServer.create({
+		instance: { dbName: "biblecomment-dev" },
+	});
+	const uri = mongo.getUri();
+	// Sanity-check the in-memory URI is local. Defends against any future
+	// mongodb-memory-server change that might emit a non-localhost address.
+	assertLocalMongoUri(uri, "dev-with-mongo in-memory mongo");
+	console.log(`[dev] mongo ready at ${uri}`);
 
-  await seed(uri);
+	await seed(uri);
 
-  const env = {
-    ...process.env,
-    MONGODB_URI: uri,
-    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || "dev-mongo-secret-not-for-prod",
-    NEXTAUTH_URL: process.env.NEXTAUTH_URL || "http://localhost:3000",
-    AUTH_TRUST_HOST: "true",
-    NODE_ENV: "development",
-    // Capture password-reset emails locally so /api/_test/last-email can
-    // hand back the link instead of relying on a real Resend account.
-    EMAIL_TRANSPORT: process.env.EMAIL_TRANSPORT ?? "memory",
-    APP_URL: process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000",
-  };
+	const env = {
+		...process.env,
+		MONGODB_URI: uri,
+		NEXTAUTH_SECRET:
+			process.env.NEXTAUTH_SECRET || "dev-mongo-secret-not-for-prod",
+		NEXTAUTH_URL: process.env.NEXTAUTH_URL || "http://localhost:3000",
+		AUTH_TRUST_HOST: "true",
+		NODE_ENV: "development",
+		// Capture password-reset emails locally so /api/_test/last-email can
+		// hand back the link instead of relying on a real Resend account.
+		EMAIL_TRANSPORT: process.env.EMAIL_TRANSPORT ?? "memory",
+		APP_URL:
+			process.env.APP_URL ??
+			process.env.NEXTAUTH_URL ??
+			"http://localhost:3000",
+	};
 
-  console.log("[dev] launching next dev on :3000 — log in as alice@cypress.test / alice-secret-123\n");
+	console.log(
+		"[dev] launching next dev on :3000 — log in as alice@cypress.test / alice-secret-123\n",
+	);
 
-  // Windows requires shell:true for .cmd shims like npm.cmd; harmless on
-  // POSIX where /usr/bin/npm is a regular executable.
-  const child = spawn("npm", ["run", "dev"], {
-    stdio: "inherit",
-    env,
-    cwd: path.resolve(__dirname, ".."),
-    shell: true,
-  });
+	// Windows requires shell:true for .cmd shims like npm.cmd; harmless on
+	// POSIX where /usr/bin/npm is a regular executable.
+	const child = spawn("npm", ["run", "dev"], {
+		stdio: "inherit",
+		env,
+		cwd: path.resolve(__dirname, ".."),
+		shell: true,
+	});
 
-  let teardownStarted = false;
-  const teardown = async (signal) => {
-    if (teardownStarted) return;
-    teardownStarted = true;
-    console.log(`\n[dev] received ${signal ?? "exit"}, tearing down...`);
-    if (!child.killed) {
-      try { child.kill("SIGTERM"); } catch { /* ignore */ }
-    }
-    try { await mongo.stop(); } catch { /* ignore */ }
-    process.exit(0);
-  };
+	let teardownStarted = false;
+	const teardown = async (signal) => {
+		if (teardownStarted) return;
+		teardownStarted = true;
+		console.log(`\n[dev] received ${signal ?? "exit"}, tearing down...`);
+		if (!child.killed) {
+			try {
+				child.kill("SIGTERM");
+			} catch {
+				/* ignore */
+			}
+		}
+		try {
+			await mongo.stop();
+		} catch {
+			/* ignore */
+		}
+		process.exit(0);
+	};
 
-  process.on("SIGINT", () => teardown("SIGINT"));
-  process.on("SIGTERM", () => teardown("SIGTERM"));
-  child.on("exit", () => teardown("child-exit"));
+	process.on("SIGINT", () => teardown("SIGINT"));
+	process.on("SIGTERM", () => teardown("SIGTERM"));
+	child.on("exit", () => teardown("child-exit"));
 }
 
 main().catch(async (err) => {
-  console.error("[dev] fatal:", err && err.message ? err.message : err);
-  process.exit(1);
+	console.error("[dev] fatal:", err && err.message ? err.message : err);
+	process.exit(1);
 });

--- a/nextjs/src/app/api/og/comment/[id]/route.tsx
+++ b/nextjs/src/app/api/og/comment/[id]/route.tsx
@@ -61,6 +61,17 @@ export async function GET(
 
 	return new ImageResponse(
 		<CommentShareCard card={card} logoDataUri={logo} format={format} />,
-		size,
+		{
+			...size,
+			// The card for a given id is near-immutable (only changes if the
+			// comment is edited). force-dynamic keeps it correct after edits,
+			// but without caching every crawler/preview hit re-runs satori +
+			// two Mongo lookups — a cheap amplification vector. Let the CDN
+			// serve it for an hour and revalidate in the background.
+			headers: {
+				"Cache-Control":
+					"public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+			},
+		},
 	);
 }

--- a/nextjs/src/app/api/og/comment/[id]/route.tsx
+++ b/nextjs/src/app/api/og/comment/[id]/route.tsx
@@ -11,50 +11,53 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 async function logoDataUri(): Promise<string> {
-  const buf = await readFile(
-    path.join(process.cwd(), "public", "assets", "logo.png"),
-  );
-  return `data:image/png;base64,${buf.toString("base64")}`;
+	const buf = await readFile(
+		path.join(process.cwd(), "public", "assets", "logo.png"),
+	);
+	return `data:image/png;base64,${buf.toString("base64")}`;
 }
 
 export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> },
+	req: Request,
+	{ params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params;
-  const format =
-    new URL(req.url).searchParams.get("format") === "wide" ? "wide" : "square";
+	const { id } = await params;
+	const format =
+		new URL(req.url).searchParams.get("format") === "wide" ? "wide" : "square";
 
-  const comment = await new MongoCommentRepository().findById(id);
-  if (!comment) {
-    return new Response("Comment not found", { status: 404 });
-  }
-  const verse = await new MongoVerseRepository().findById(comment.verseId);
+	const comment = await new MongoCommentRepository().findById(id);
+	if (!comment) {
+		return new Response("Comment not found", { status: 404 });
+	}
+	const verse = await new MongoVerseRepository().findById(comment.verseId);
 
-  const card = commentToCardProps(
-    {
-      _id: comment._id,
-      text: comment.text,
-      username: comment.username,
-      tags: comment.tags,
-      verified: comment.verified,
-      communitySlug: comment.communitySlug,
-      bookReference: comment.bookReference,
-    },
-    verse ?? {
-      abbrev: "",
-      chapter: 0,
-      verseNumber: 0,
-      reference: comment.bookReference,
-    },
-    new URL(req.url).origin,
-  );
+	const card = commentToCardProps(
+		{
+			_id: comment._id,
+			text: comment.text,
+			username: comment.username,
+			tags: comment.tags,
+			verified: comment.verified,
+			communitySlug: comment.communitySlug,
+			bookReference: comment.bookReference,
+		},
+		verse ?? {
+			abbrev: "",
+			chapter: 0,
+			verseNumber: 0,
+			reference: comment.bookReference,
+		},
+		new URL(req.url).origin,
+	);
 
-  const logo = await logoDataUri();
-  const size = format === "wide" ? { width: 1200, height: 630 } : { width: 1080, height: 1080 };
+	const logo = await logoDataUri();
+	const size =
+		format === "wide"
+			? { width: 1200, height: 630 }
+			: { width: 1080, height: 1080 };
 
-  return new ImageResponse(
-    <CommentShareCard card={card} logoDataUri={logo} format={format} />,
-    size,
-  );
+	return new ImageResponse(
+		<CommentShareCard card={card} logoDataUri={logo} format={format} />,
+		size,
+	);
 }

--- a/nextjs/src/app/api/og/comment/[id]/route.tsx
+++ b/nextjs/src/app/api/og/comment/[id]/route.tsx
@@ -1,0 +1,60 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "fs/promises";
+import path from "path";
+import { MongoCommentRepository } from "@/infrastructure/repositories/MongoCommentRepository";
+import { MongoVerseRepository } from "@/infrastructure/repositories/MongoVerseRepository";
+import { commentToCardProps } from "@/lib/share-comment";
+import { CommentShareCard } from "@/components/CommentShareCard";
+
+// Mongoose is not edge-safe and we read the logo from disk — Node runtime.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function logoDataUri(): Promise<string> {
+  const buf = await readFile(
+    path.join(process.cwd(), "public", "assets", "logo.png"),
+  );
+  return `data:image/png;base64,${buf.toString("base64")}`;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const format =
+    new URL(req.url).searchParams.get("format") === "wide" ? "wide" : "square";
+
+  const comment = await new MongoCommentRepository().findById(id);
+  if (!comment) {
+    return new Response("Comment not found", { status: 404 });
+  }
+  const verse = await new MongoVerseRepository().findById(comment.verseId);
+
+  const card = commentToCardProps(
+    {
+      _id: comment._id,
+      text: comment.text,
+      username: comment.username,
+      tags: comment.tags,
+      verified: comment.verified,
+      communitySlug: comment.communitySlug,
+      bookReference: comment.bookReference,
+    },
+    verse ?? {
+      abbrev: "",
+      chapter: 0,
+      verseNumber: 0,
+      reference: comment.bookReference,
+    },
+    new URL(req.url).origin,
+  );
+
+  const logo = await logoDataUri();
+  const size = format === "wide" ? { width: 1200, height: 630 } : { width: 1080, height: 1080 };
+
+  return new ImageResponse(
+    <CommentShareCard card={card} logoDataUri={logo} format={format} />,
+    size,
+  );
+}

--- a/nextjs/src/app/api/og/comment/[id]/route.tsx
+++ b/nextjs/src/app/api/og/comment/[id]/route.tsx
@@ -10,9 +10,12 @@ import { CommentShareCard } from "@/components/CommentShareCard";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+// public/assets/logo.png is actually a JPEG (mislabeled), which satori
+// silently fails to decode — the card rendered with a blank logo slot.
+// icon-512.png is a real, square, transparent PNG (the app/PWA mark).
 async function logoDataUri(): Promise<string> {
 	const buf = await readFile(
-		path.join(process.cwd(), "public", "assets", "logo.png"),
+		path.join(process.cwd(), "public", "icons", "icon-512.png"),
 	);
 	return `data:image/png;base64,${buf.toString("base64")}`;
 }

--- a/nextjs/src/app/c/[id]/ShareForward.tsx
+++ b/nextjs/src/app/c/[id]/ShareForward.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Humans hitting a shared /c/<id> link get bounced to the verse in context.
+ * We do NOT server-redirect (a 307 would make social crawlers follow it and
+ * read the verse page's meta instead of the comment card). Crawlers don't
+ * run JS, so they stay on /c/<id> and read its OG/Twitter meta; humans get
+ * router.replace'd here, with a plain link as the no-JS fallback.
+ */
+export function ShareForward({ href }: { href: string }) {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace(href);
+  }, [router, href]);
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+        textAlign: "center",
+      }}
+    >
+      <p>
+        Abrindo o comentário no contexto…{" "}
+        <a href={href} className="text-brand underline">
+          Toque aqui se não for redirecionado
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/nextjs/src/app/c/[id]/ShareForward.tsx
+++ b/nextjs/src/app/c/[id]/ShareForward.tsx
@@ -17,22 +17,42 @@ export function ShareForward({ href }: { href: string }) {
 	}, [router, href]);
 
 	return (
-		<div
-			style={{
-				minHeight: "100vh",
-				display: "flex",
-				alignItems: "center",
-				justifyContent: "center",
-				padding: 24,
-				textAlign: "center",
-			}}
-		>
-			<p>
-				Abrindo o comentário no contexto…{" "}
-				<a href={href} className="text-brand underline">
+		<div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-950 px-6">
+			<div className="flex flex-col items-center gap-6 text-center max-w-sm">
+				{/* eslint-disable-next-line @next/next/no-img-element */}
+				<img
+					src="/assets/logo.svg"
+					alt=""
+					aria-hidden="true"
+					width={64}
+					height={64}
+					className="w-16 h-16"
+				/>
+				<div>
+					<div className="font-bold text-lg text-slate-800 dark:text-slate-100 leading-tight">
+						BibleComment
+					</div>
+					<div className="font-light text-xs text-[#888] dark:text-slate-400">
+						A Program for His Glory
+					</div>
+				</div>
+
+				<div
+					className="w-7 h-7 rounded-full border-2 border-slate-200 dark:border-slate-700 border-t-brand animate-spin"
+					role="status"
+					aria-label="Carregando"
+				/>
+
+				<p className="text-sm text-slate-600 dark:text-slate-300 m-0">
+					Abrindo o comentário no contexto…
+				</p>
+				<a
+					href={href}
+					className="text-sm font-semibold text-brand hover:underline"
+				>
 					Toque aqui se não for redirecionado
 				</a>
-			</p>
+			</div>
 		</div>
 	);
 }

--- a/nextjs/src/app/c/[id]/ShareForward.tsx
+++ b/nextjs/src/app/c/[id]/ShareForward.tsx
@@ -11,28 +11,28 @@ import { useRouter } from "next/navigation";
  * router.replace'd here, with a plain link as the no-JS fallback.
  */
 export function ShareForward({ href }: { href: string }) {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace(href);
-  }, [router, href]);
+	const router = useRouter();
+	useEffect(() => {
+		router.replace(href);
+	}, [router, href]);
 
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: 24,
-        textAlign: "center",
-      }}
-    >
-      <p>
-        Abrindo o comentário no contexto…{" "}
-        <a href={href} className="text-brand underline">
-          Toque aqui se não for redirecionado
-        </a>
-      </p>
-    </div>
-  );
+	return (
+		<div
+			style={{
+				minHeight: "100vh",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 24,
+				textAlign: "center",
+			}}
+		>
+			<p>
+				Abrindo o comentário no contexto…{" "}
+				<a href={href} className="text-brand underline">
+					Toque aqui se não for redirecionado
+				</a>
+			</p>
+		</div>
+	);
 }

--- a/nextjs/src/app/c/[id]/page.tsx
+++ b/nextjs/src/app/c/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MongoCommentRepository } from "@/infrastructure/repositories/MongoCommentRepository";
@@ -15,13 +16,22 @@ interface PageProps {
 
 export const dynamic = "force-dynamic";
 
+// generateMetadata and the page component both need the comment + its
+// verse. React.cache dedupes the lookups within a single request so
+// /c/<id> does one DB round-trip per resource instead of two.
+const loadShared = cache(async (id: string) => {
+	const comment = await new MongoCommentRepository().findById(id);
+	if (!comment) return { comment: null, verse: null };
+	const verse = await new MongoVerseRepository().findById(comment.verseId);
+	return { comment, verse };
+});
+
 export async function generateMetadata({
 	params,
 }: PageProps): Promise<Metadata> {
 	const { id } = await params;
-	const comment = await new MongoCommentRepository().findById(id);
+	const { comment, verse } = await loadShared(id);
 	if (!comment) return { title: "Comentário — Bible Comment" };
-	const verse = await new MongoVerseRepository().findById(comment.verseId);
 	const ref = formatCommentReference(comment, verse ?? undefined);
 	const title = `@${comment.username} em ${ref} — Bible Comment`;
 	const description = clampForCard(comment.text, 160);
@@ -48,9 +58,8 @@ export async function generateMetadata({
 
 export default async function CommentSharePage({ params }: PageProps) {
 	const { id } = await params;
-	const comment = await new MongoCommentRepository().findById(id);
+	const { comment, verse } = await loadShared(id);
 	if (!comment) notFound();
-	const verse = await new MongoVerseRepository().findById(comment.verseId);
 	const href = verse ? verseDeepLinkPath(verse) : "/home";
 	return <ShareForward href={href} />;
 }

--- a/nextjs/src/app/c/[id]/page.tsx
+++ b/nextjs/src/app/c/[id]/page.tsx
@@ -3,49 +3,54 @@ import { notFound } from "next/navigation";
 import { MongoCommentRepository } from "@/infrastructure/repositories/MongoCommentRepository";
 import { MongoVerseRepository } from "@/infrastructure/repositories/MongoVerseRepository";
 import {
-  clampForCard,
-  formatCommentReference,
-  verseDeepLinkPath,
+	clampForCard,
+	formatCommentReference,
+	verseDeepLinkPath,
 } from "@/lib/share-comment";
 import { ShareForward } from "./ShareForward";
 
 interface PageProps {
-  params: Promise<{ id: string }>;
+	params: Promise<{ id: string }>;
 }
 
 export const dynamic = "force-dynamic";
 
 export async function generateMetadata({
-  params,
+	params,
 }: PageProps): Promise<Metadata> {
-  const { id } = await params;
-  const comment = await new MongoCommentRepository().findById(id);
-  if (!comment) return { title: "Comentário — Bible Comment" };
-  const verse = await new MongoVerseRepository().findById(comment.verseId);
-  const ref = formatCommentReference(comment, verse ?? undefined);
-  const title = `@${comment.username} em ${ref} — Bible Comment`;
-  const description = clampForCard(comment.text, 160);
-  // metadataBase is set in app/layout.tsx, so a relative image path resolves
-  // to an absolute URL for crawlers. ?format=wide = 1200x630 unfurl.
-  const image = `/api/og/comment/${id}?format=wide`;
-  return {
-    title,
-    description,
-    openGraph: {
-      title,
-      description,
-      images: [{ url: image, width: 1200, height: 630 }],
-      type: "article",
-    },
-    twitter: { card: "summary_large_image", title, description, images: [image] },
-  };
+	const { id } = await params;
+	const comment = await new MongoCommentRepository().findById(id);
+	if (!comment) return { title: "Comentário — Bible Comment" };
+	const verse = await new MongoVerseRepository().findById(comment.verseId);
+	const ref = formatCommentReference(comment, verse ?? undefined);
+	const title = `@${comment.username} em ${ref} — Bible Comment`;
+	const description = clampForCard(comment.text, 160);
+	// metadataBase is set in app/layout.tsx, so a relative image path resolves
+	// to an absolute URL for crawlers. ?format=wide = 1200x630 unfurl.
+	const image = `/api/og/comment/${id}?format=wide`;
+	return {
+		title,
+		description,
+		openGraph: {
+			title,
+			description,
+			images: [{ url: image, width: 1200, height: 630 }],
+			type: "article",
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+			images: [image],
+		},
+	};
 }
 
 export default async function CommentSharePage({ params }: PageProps) {
-  const { id } = await params;
-  const comment = await new MongoCommentRepository().findById(id);
-  if (!comment) notFound();
-  const verse = await new MongoVerseRepository().findById(comment.verseId);
-  const href = verse ? verseDeepLinkPath(verse) : "/home";
-  return <ShareForward href={href} />;
+	const { id } = await params;
+	const comment = await new MongoCommentRepository().findById(id);
+	if (!comment) notFound();
+	const verse = await new MongoVerseRepository().findById(comment.verseId);
+	const href = verse ? verseDeepLinkPath(verse) : "/home";
+	return <ShareForward href={href} />;
 }

--- a/nextjs/src/app/c/[id]/page.tsx
+++ b/nextjs/src/app/c/[id]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { MongoCommentRepository } from "@/infrastructure/repositories/MongoCommentRepository";
+import { MongoVerseRepository } from "@/infrastructure/repositories/MongoVerseRepository";
+import {
+  clampForCard,
+  formatCommentReference,
+  verseDeepLinkPath,
+} from "@/lib/share-comment";
+import { ShareForward } from "./ShareForward";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const comment = await new MongoCommentRepository().findById(id);
+  if (!comment) return { title: "Comentário — Bible Comment" };
+  const verse = await new MongoVerseRepository().findById(comment.verseId);
+  const ref = formatCommentReference(comment, verse ?? undefined);
+  const title = `@${comment.username} em ${ref} — Bible Comment`;
+  const description = clampForCard(comment.text, 160);
+  // metadataBase is set in app/layout.tsx, so a relative image path resolves
+  // to an absolute URL for crawlers. ?format=wide = 1200x630 unfurl.
+  const image = `/api/og/comment/${id}?format=wide`;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [{ url: image, width: 1200, height: 630 }],
+      type: "article",
+    },
+    twitter: { card: "summary_large_image", title, description, images: [image] },
+  };
+}
+
+export default async function CommentSharePage({ params }: PageProps) {
+  const { id } = await params;
+  const comment = await new MongoCommentRepository().findById(id);
+  if (!comment) notFound();
+  const verse = await new MongoVerseRepository().findById(comment.verseId);
+  const href = verse ? verseDeepLinkPath(verse) : "/home";
+  return <ShareForward href={href} />;
+}

--- a/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
+++ b/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
@@ -6,7 +6,10 @@ import Link from "next/link";
 import { useNotification } from "@/contexts/NotificationContext";
 import { useConfirm } from "@/contexts/ConfirmContext";
 import { commentsService } from "@/services/comments";
-import { useCommunityFilter, GENERAL_BUCKET } from "@/lib/hooks/useCommunityFilter";
+import {
+	useCommunityFilter,
+	GENERAL_BUCKET,
+} from "@/lib/hooks/useCommunityFilter";
 import { Book } from "@/domain/entities/Book";
 import { Verse } from "@/domain/entities/Verse";
 import type { CommentData } from "@/lib/comment-data";
@@ -22,1190 +25,1622 @@ import { TagIcon } from "@/components/TagIcon";
 import { TagBadges } from "@/components/TagBadges";
 import { ShareCommentButton } from "@/components/ShareCommentButton";
 import {
-  toggleLikeAction,
-  reportCommentAction,
-  deleteCommentAction,
-  createCommentAction,
-  updateCommentAction,
+	toggleLikeAction,
+	reportCommentAction,
+	deleteCommentAction,
+	createCommentAction,
+	updateCommentAction,
 } from "@/app/actions/comments";
 import { toggleCommentVerifiedAction } from "@/app/actions/moderation";
 
 interface SessionUser {
-  name: string;
-  email: string;
-  username: string;
-  moderator: boolean;
+	name: string;
+	email: string;
+	username: string;
+	moderator: boolean;
 }
 
 interface Props {
-  book: Book;
-  verses: Verse[];
-  chapter: number;
-  /**
-   * The signed-in user, or null for an anonymous reader. Reading is
-   * always allowed; write actions (composing, liking, reporting, opening
-   * a discussion, deleting) bounce through /login when user is null.
-   */
-  user: SessionUser | null;
-  /**
-   * Has the user completed the chapter tutorial on any device? Sourced from
-   * the auth session (JWT, populated at login). Lets the tour skip itself
-   * for a fresh browser of an already-onboarded user without waiting on
-   * localStorage. Always false for anonymous readers.
-   */
-  tutorialAlreadyCompleted: boolean;
-  /**
-   * Whether the signed-in user has marked this chapter as read.
-   * Always false for anonymous readers (the button hides for them too).
-   */
-  alreadyRead: boolean;
-  /**
-   * Per-verse comment counts (non-title) and total title-mode comment count,
-   * pre-computed server-side. When provided, ChapterClient paints badges on
-   * first render and skips the mount-time axios fetch.
-   */
-  initialCountMap?: Record<string, number>;
-  initialTitleCount?: number;
+	book: Book;
+	verses: Verse[];
+	chapter: number;
+	/**
+	 * The signed-in user, or null for an anonymous reader. Reading is
+	 * always allowed; write actions (composing, liking, reporting, opening
+	 * a discussion, deleting) bounce through /login when user is null.
+	 */
+	user: SessionUser | null;
+	/**
+	 * Has the user completed the chapter tutorial on any device? Sourced from
+	 * the auth session (JWT, populated at login). Lets the tour skip itself
+	 * for a fresh browser of an already-onboarded user without waiting on
+	 * localStorage. Always false for anonymous readers.
+	 */
+	tutorialAlreadyCompleted: boolean;
+	/**
+	 * Whether the signed-in user has marked this chapter as read.
+	 * Always false for anonymous readers (the button hides for them too).
+	 */
+	alreadyRead: boolean;
+	/**
+	 * Per-verse comment counts (non-title) and total title-mode comment count,
+	 * pre-computed server-side. When provided, ChapterClient paints badges on
+	 * first render and skips the mount-time axios fetch.
+	 */
+	initialCountMap?: Record<string, number>;
+	initialTitleCount?: number;
 }
 
 const MIN_LEN = 200;
 const MAX_LEN = 1000;
 
 function dateFormat(str: string) {
-  try {
-    return new Date(str).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", year: "numeric" });
-  } catch {
-    return str;
-  }
+	try {
+		return new Date(str).toLocaleDateString("pt-BR", {
+			day: "2-digit",
+			month: "2-digit",
+			year: "numeric",
+		});
+	} catch {
+		return str;
+	}
 }
 
 export default function ChapterClient({
-  book,
-  verses,
-  chapter,
-  user,
-  tutorialAlreadyCompleted,
-  alreadyRead,
-  initialCountMap,
-  initialTitleCount,
+	book,
+	verses,
+	chapter,
+	user,
+	tutorialAlreadyCompleted,
+	alreadyRead,
+	initialCountMap,
+	initialTitleCount,
 }: Props) {
-  const router = useRouter();
-  const { handleNotification } = useNotification();
-  const confirm = useConfirm();
+	const router = useRouter();
+	const { handleNotification } = useNotification();
+	const confirm = useConfirm();
 
-  const [selectedVerse, setSelectedVerse] = useState<Verse | null>(null);
-  const [isTitleMode, setIsTitleMode] = useState(false);
-  const [comments, setComments] = useState<CommentData[]>([]);
-  const [titleComments, setTitleComments] = useState<CommentData[]>([]);
-  const [loadingComments, setLoadingComments] = useState(false);
-  const [countMap, setCountMap] = useState<Record<string, number>>(initialCountMap ?? {});
-  const [titleCount, setTitleCount] = useState(initialTitleCount ?? 0);
-  // Counts are seeded from server props; only refetch client-side when the
-  // server didn't supply them (legacy callers / tests). Future writes update
-  // the maps directly via setCountMap / setTitleCount so no refresh is needed.
-  const hasInitialCounts = initialCountMap !== undefined && initialTitleCount !== undefined;
+	const [selectedVerse, setSelectedVerse] = useState<Verse | null>(null);
+	const [isTitleMode, setIsTitleMode] = useState(false);
+	const [comments, setComments] = useState<CommentData[]>([]);
+	const [titleComments, setTitleComments] = useState<CommentData[]>([]);
+	const [loadingComments, setLoadingComments] = useState(false);
+	const [countMap, setCountMap] = useState<Record<string, number>>(
+		initialCountMap ?? {},
+	);
+	const [titleCount, setTitleCount] = useState(initialTitleCount ?? 0);
+	// Counts are seeded from server props; only refetch client-side when the
+	// server didn't supply them (legacy callers / tests). Future writes update
+	// the maps directly via setCountMap / setTitleCount so no refresh is needed.
+	const hasInitialCounts =
+		initialCountMap !== undefined && initialTitleCount !== undefined;
 
-  const [composing, setComposing] = useState(false);
-  const [composeText, setComposeText] = useState("");
-  const [composeTags, setComposeTags] = useState<Record<string, boolean>>({
-    devocional: false, exegese: false, pessoal: false, inspirado: false,
-  });
-  const [composeCommunity, setComposeCommunity] = useState<string>("");
-  const [userCommunities, setUserCommunities] = useState<{ slug: string; name: string }[]>([]);
-  const communityFilter = useCommunityFilter(user?.username);
-  const [composeSubmitting, setComposeSubmitting] = useState(false);
-  const [editingComment, setEditingComment] = useState<CommentData | null>(null);
-  const [editText, setEditText] = useState("");
-  const [editTags, setEditTags] = useState<Record<string, boolean>>({
-    devocional: false, exegese: false, pessoal: false, inspirado: false,
-  });
+	const [composing, setComposing] = useState(false);
+	const [composeText, setComposeText] = useState("");
+	const [composeTags, setComposeTags] = useState<Record<string, boolean>>({
+		devocional: false,
+		exegese: false,
+		pessoal: false,
+		inspirado: false,
+	});
+	const [composeCommunity, setComposeCommunity] = useState<string>("");
+	const [userCommunities, setUserCommunities] = useState<
+		{ slug: string; name: string }[]
+	>([]);
+	const communityFilter = useCommunityFilter(user?.username);
+	const [composeSubmitting, setComposeSubmitting] = useState(false);
+	const [editingComment, setEditingComment] = useState<CommentData | null>(
+		null,
+	);
+	const [editText, setEditText] = useState("");
+	const [editTags, setEditTags] = useState<Record<string, boolean>>({
+		devocional: false,
+		exegese: false,
+		pessoal: false,
+		inspirado: false,
+	});
 
-  const sidebarRef = useRef<HTMLDivElement>(null);
+	const sidebarRef = useRef<HTMLDivElement>(null);
 
-  // Onboarding tour. Renders on first visit (any chapter) until the user
-  // finishes or skips it. URL ?tour=1 forces a re-run regardless of the
-  // localStorage flag — used by the "Refazer tutorial" button on /profile.
-  // useSearchParams (App Router hook) is the hydration-safe way to read
-  // the query string; reading window.location.search directly during
-  // render trips a SSR/CSR mismatch in production.
-  // syncServer + initialFromServer give us cross-device behavior: the JWT
-  // carries `tutorialsCompleted`, so a fresh browser of an already-onboarded
-  // user skips the tour without waiting on localStorage. The tour is
-  // skipped entirely for anonymous readers — the actions it teaches all
-  // require an account anyway.
-  const tutorial = useTutorial(CHAPTER_TUTORIAL_NAME, {
-    syncServer: !!user,
-    initialFromServer: tutorialAlreadyCompleted,
-  });
-  const searchParams = useSearchParams();
-  const forceTour = searchParams?.get("tour") === "1";
-  const showTutorial = !!user && (forceTour || tutorial.isCompleted === false);
+	// Onboarding tour. Renders on first visit (any chapter) until the user
+	// finishes or skips it. URL ?tour=1 forces a re-run regardless of the
+	// localStorage flag — used by the "Refazer tutorial" button on /profile.
+	// useSearchParams (App Router hook) is the hydration-safe way to read
+	// the query string; reading window.location.search directly during
+	// render trips a SSR/CSR mismatch in production.
+	// syncServer + initialFromServer give us cross-device behavior: the JWT
+	// carries `tutorialsCompleted`, so a fresh browser of an already-onboarded
+	// user skips the tour without waiting on localStorage. The tour is
+	// skipped entirely for anonymous readers — the actions it teaches all
+	// require an account anyway.
+	const tutorial = useTutorial(CHAPTER_TUTORIAL_NAME, {
+		syncServer: !!user,
+		initialFromServer: tutorialAlreadyCompleted,
+	});
+	const searchParams = useSearchParams();
+	const forceTour = searchParams?.get("tour") === "1";
+	const showTutorial = !!user && (forceTour || tutorial.isCompleted === false);
 
-  const prevChapter = chapter > 1 ? chapter - 1 : null;
-  const nextChapter = chapter < book.chapters ? chapter + 1 : null;
+	const prevChapter = chapter > 1 ? chapter - 1 : null;
+	const nextChapter = chapter < book.chapters ? chapter + 1 : null;
 
-  const activeComments = isTitleMode ? titleComments : comments;
+	const activeComments = isTitleMode ? titleComments : comments;
 
-  const loadCounts = useCallback(async () => {
-    try {
-      const res = await commentsService.getForChapter(
-        book.abbrev,
-        chapter,
-        communityFilter.selected,
-      );
-      const tc = (res.titleComments ?? []) as unknown as CommentData[];
-      const vc = (res.verseComments ?? []) as unknown as CommentData[];
-      setTitleCount(tc.length);
-      const map: Record<string, number> = {};
-      vc.forEach((c) => {
-        if (c.verseId) map[c.verseId] = (map[c.verseId] ?? 0) + 1;
-      });
-      setCountMap(map);
-    } catch {
-      // Comment counts are non-critical UI metadata; failures shouldn't surface.
-    }
-  }, [book.abbrev, chapter, communityFilter.selected]);
+	const loadCounts = useCallback(async () => {
+		try {
+			const res = await commentsService.getForChapter(
+				book.abbrev,
+				chapter,
+				communityFilter.selected,
+			);
+			const tc = (res.titleComments ?? []) as unknown as CommentData[];
+			const vc = (res.verseComments ?? []) as unknown as CommentData[];
+			setTitleCount(tc.length);
+			const map: Record<string, number> = {};
+			vc.forEach((c) => {
+				if (c.verseId) map[c.verseId] = (map[c.verseId] ?? 0) + 1;
+			});
+			setCountMap(map);
+		} catch {
+			// Comment counts are non-critical UI metadata; failures shouldn't surface.
+		}
+	}, [book.abbrev, chapter, communityFilter.selected]);
 
-  useEffect(() => {
-    // Skip the first paint when SSR already provided counts (no filter), but
-    // re-fetch on every filter change so the per-verse badges reflect the
-    // selected communities.
-    if (hasInitialCounts && communityFilter.selected === null) return;
-    loadCounts();
-  }, [hasInitialCounts, loadCounts, communityFilter.selected]);
+	useEffect(() => {
+		// Skip the first paint when SSR already provided counts (no filter), but
+		// re-fetch on every filter change so the per-verse badges reflect the
+		// selected communities.
+		if (hasInitialCounts && communityFilter.selected === null) return;
+		loadCounts();
+	}, [hasInitialCounts, loadCounts, communityFilter.selected]);
 
-  // Reload the open panel's comments whenever the filter changes — keeps
-  // the sidebar in sync with the chips without making the user close +
-  // reopen the verse panel. Inlined here (rather than calling openVersePanel)
-  // because the open* helpers double as toggles: invoking them on the
-  // already-selected verse closes the panel.
-  useEffect(() => {
-    let cancelled = false;
-    async function refresh() {
-      if (isTitleMode) {
-        try {
-          const res = await commentsService.getForChapter(
-            book.abbrev,
-            chapter,
-            communityFilter.selected,
-          );
-          if (!cancelled) setTitleComments((res.titleComments ?? []) as unknown as CommentData[]);
-        } catch {
-          // Filter change isn't a user action; suppress the toast — the
-          // existing comments stay rendered until the next interaction.
-        }
-      } else if (selectedVerse) {
-        try {
-          const res = await commentsService.getForVerse(
-            book.abbrev,
-            chapter,
-            selectedVerse.verseNumber,
-            communityFilter.selected,
-          );
-          if (!cancelled) setComments((res.verseComments ?? []) as unknown as CommentData[]);
-        } catch {}
-      }
-    }
-    refresh();
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [communityFilter.selected]);
+	// Reload the open panel's comments whenever the filter changes — keeps
+	// the sidebar in sync with the chips without making the user close +
+	// reopen the verse panel. Inlined here (rather than calling openVersePanel)
+	// because the open* helpers double as toggles: invoking them on the
+	// already-selected verse closes the panel.
+	useEffect(() => {
+		let cancelled = false;
+		async function refresh() {
+			if (isTitleMode) {
+				try {
+					const res = await commentsService.getForChapter(
+						book.abbrev,
+						chapter,
+						communityFilter.selected,
+					);
+					if (!cancelled)
+						setTitleComments(
+							(res.titleComments ?? []) as unknown as CommentData[],
+						);
+				} catch {
+					// Filter change isn't a user action; suppress the toast — the
+					// existing comments stay rendered until the next interaction.
+				}
+			} else if (selectedVerse) {
+				try {
+					const res = await commentsService.getForVerse(
+						book.abbrev,
+						chapter,
+						selectedVerse.verseNumber,
+						communityFilter.selected,
+					);
+					if (!cancelled)
+						setComments((res.verseComments ?? []) as unknown as CommentData[]);
+				} catch {}
+			}
+		}
+		refresh();
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [communityFilter.selected]);
 
-  // Fetch the user's communities once, on mount, so the "Postar em" select
-  // is already populated when the composer opens. Anonymous viewers skip the
-  // fetch entirely — the endpoint returns [] for them anyway, but cutting
-  // the request keeps the network panel clean.
-  useEffect(() => {
-    if (!user) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/api/users/me/communities");
-        if (!res.ok) return;
-        const data = (await res.json()) as { items: { slug: string; name: string }[] };
-        if (!cancelled) setUserCommunities(data.items);
-      } catch {
-        // Non-critical metadata fetch — silently keep the select empty.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [user]);
+	// Fetch the user's communities once, on mount, so the "Postar em" select
+	// is already populated when the composer opens. Anonymous viewers skip the
+	// fetch entirely — the endpoint returns [] for them anyway, but cutting
+	// the request keeps the network panel clean.
+	useEffect(() => {
+		if (!user) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch("/api/users/me/communities");
+				if (!res.ok) return;
+				const data = (await res.json()) as {
+					items: { slug: string; name: string }[];
+				};
+				if (!cancelled) setUserCommunities(data.items);
+			} catch {
+				// Non-critical metadata fetch — silently keep the select empty.
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [user]);
 
-  const openTitlePanel = useCallback(async () => {
-    setIsTitleMode(true);
-    setSelectedVerse(null);
-    setComposing(false);
-    setLoadingComments(true);
-    try {
-      const res = await commentsService.getForChapter(
-        book.abbrev,
-        chapter,
-        communityFilter.selected,
-      );
-      setTitleComments((res.titleComments ?? []) as unknown as CommentData[]);
-    } catch {
-      handleNotification("error", "Erro ao carregar comentários do capítulo.");
-    } finally {
-      setLoadingComments(false);
-    }
-  }, [book.abbrev, chapter, communityFilter.selected, handleNotification]);
+	const openTitlePanel = useCallback(async () => {
+		setIsTitleMode(true);
+		setSelectedVerse(null);
+		setComposing(false);
+		setLoadingComments(true);
+		try {
+			const res = await commentsService.getForChapter(
+				book.abbrev,
+				chapter,
+				communityFilter.selected,
+			);
+			setTitleComments((res.titleComments ?? []) as unknown as CommentData[]);
+		} catch {
+			handleNotification("error", "Erro ao carregar comentários do capítulo.");
+		} finally {
+			setLoadingComments(false);
+		}
+	}, [book.abbrev, chapter, communityFilter.selected, handleNotification]);
 
-  const openVersePanel = useCallback(async (verse: Verse) => {
-    if (selectedVerse?._id === verse._id && !isTitleMode) {
-      setSelectedVerse(null);
-      setComposing(false);
-      return;
-    }
-    setIsTitleMode(false);
-    setSelectedVerse(verse);
-    setComposing(false);
-    setLoadingComments(true);
-    try {
-      const res = await commentsService.getForVerse(
-        book.abbrev,
-        chapter,
-        verse.verseNumber,
-        communityFilter.selected,
-      );
-      setComments((res.verseComments ?? []) as unknown as CommentData[]);
-    } catch {
-      handleNotification("error", "Erro ao carregar comentários.");
-    } finally {
-      setLoadingComments(false);
-    }
-  }, [book.abbrev, chapter, isTitleMode, selectedVerse, communityFilter.selected, handleNotification]);
+	const openVersePanel = useCallback(
+		async (verse: Verse) => {
+			if (selectedVerse?._id === verse._id && !isTitleMode) {
+				setSelectedVerse(null);
+				setComposing(false);
+				return;
+			}
+			setIsTitleMode(false);
+			setSelectedVerse(verse);
+			setComposing(false);
+			setLoadingComments(true);
+			try {
+				const res = await commentsService.getForVerse(
+					book.abbrev,
+					chapter,
+					verse.verseNumber,
+					communityFilter.selected,
+				);
+				setComments((res.verseComments ?? []) as unknown as CommentData[]);
+			} catch {
+				handleNotification("error", "Erro ao carregar comentários.");
+			} finally {
+				setLoadingComments(false);
+			}
+		},
+		[
+			book.abbrev,
+			chapter,
+			isTitleMode,
+			selectedVerse,
+			communityFilter.selected,
+			handleNotification,
+		],
+	);
 
-  const handleClose = useCallback(() => {
-    setSelectedVerse(null);
-    setIsTitleMode(false);
-    setComposing(false);
-    setComments([]);
-    setTitleComments([]);
-  }, []);
+	const handleClose = useCallback(() => {
+		setSelectedVerse(null);
+		setIsTitleMode(false);
+		setComposing(false);
+		setComments([]);
+		setTitleComments([]);
+	}, []);
 
-  const resetCompose = useCallback(() => {
-    setComposeText("");
-    setComposeTags({ devocional: false, exegese: false, pessoal: false, inspirado: false });
-    setComposeCommunity("");
-    setComposing(false);
-  }, []);
+	const resetCompose = useCallback(() => {
+		setComposeText("");
+		setComposeTags({
+			devocional: false,
+			exegese: false,
+			pessoal: false,
+			inspirado: false,
+		});
+		setComposeCommunity("");
+		setComposing(false);
+	}, []);
 
-  // Push the visitor to /login with a callback that returns them right
-  // back to where they were trying to act. Called by every write handler
-  // when `user` is null.
-  const requireLogin = useCallback(() => {
-    if (typeof window === "undefined") {
-      router.push("/login");
-      return;
-    }
-    const cb = encodeURIComponent(window.location.pathname + window.location.search);
-    router.push(`/login?callbackUrl=${cb}`);
-  }, [router]);
+	// Push the visitor to /login with a callback that returns them right
+	// back to where they were trying to act. Called by every write handler
+	// when `user` is null.
+	const requireLogin = useCallback(() => {
+		if (typeof window === "undefined") {
+			router.push("/login");
+			return;
+		}
+		const cb = encodeURIComponent(
+			window.location.pathname + window.location.search,
+		);
+		router.push(`/login?callbackUrl=${cb}`);
+	}, [router]);
 
-  const handleCompose = useCallback(async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!user) { requireLogin(); return; }
-    if (composeText.length < MIN_LEN || composeText.length > MAX_LEN) {
-      handleNotification("info", `Comentário deve ter entre ${MIN_LEN} e ${MAX_LEN} caracteres.`);
-      return;
-    }
-    const tagList = Object.entries(composeTags).filter(([, v]) => v).map(([k]) => k);
-    setComposeSubmitting(true);
-    try {
-      const verseId = isTitleMode
-        ? `${book.abbrev}/${chapter}`
-        : `${book.abbrev}/${chapter}/${selectedVerse?.verseNumber ?? 1}`;
-      const result = await createCommentAction(verseId, {
-        onTitle: isTitleMode,
-        text: composeText,
-        tags: tagList,
-        communitySlug: composeCommunity || undefined,
-      });
-      if (!result.ok) {
-        handleNotification("error", result.error || "Erro ao publicar.");
-        return;
-      }
-      const created = result.data as unknown as CommentData;
-      handleNotification("success", "Comentário publicado!");
-      if (isTitleMode) {
-        setTitleComments((prev) => [created, ...prev]);
-        setTitleCount((n) => n + 1);
-      } else {
-        setComments((prev) => [created, ...prev]);
-        if (selectedVerse?._id) {
-          setCountMap((prev) => ({ ...prev, [selectedVerse._id!]: (prev[selectedVerse._id!] ?? 0) + 1 }));
-        }
-      }
-      resetCompose();
-    } finally {
-      setComposeSubmitting(false);
-    }
-  }, [user, requireLogin, composeText, composeTags, composeCommunity, isTitleMode, book.abbrev, chapter, selectedVerse, handleNotification, resetCompose]);
+	const handleCompose = useCallback(
+		async (e: React.FormEvent) => {
+			e.preventDefault();
+			if (!user) {
+				requireLogin();
+				return;
+			}
+			if (composeText.length < MIN_LEN || composeText.length > MAX_LEN) {
+				handleNotification(
+					"info",
+					`Comentário deve ter entre ${MIN_LEN} e ${MAX_LEN} caracteres.`,
+				);
+				return;
+			}
+			const tagList = Object.entries(composeTags)
+				.filter(([, v]) => v)
+				.map(([k]) => k);
+			setComposeSubmitting(true);
+			try {
+				const verseId = isTitleMode
+					? `${book.abbrev}/${chapter}`
+					: `${book.abbrev}/${chapter}/${selectedVerse?.verseNumber ?? 1}`;
+				const result = await createCommentAction(verseId, {
+					onTitle: isTitleMode,
+					text: composeText,
+					tags: tagList,
+					communitySlug: composeCommunity || undefined,
+				});
+				if (!result.ok) {
+					handleNotification("error", result.error || "Erro ao publicar.");
+					return;
+				}
+				const created = result.data as unknown as CommentData;
+				handleNotification("success", "Comentário publicado!");
+				if (isTitleMode) {
+					setTitleComments((prev) => [created, ...prev]);
+					setTitleCount((n) => n + 1);
+				} else {
+					setComments((prev) => [created, ...prev]);
+					if (selectedVerse?._id) {
+						setCountMap((prev) => ({
+							...prev,
+							[selectedVerse._id!]: (prev[selectedVerse._id!] ?? 0) + 1,
+						}));
+					}
+				}
+				resetCompose();
+			} finally {
+				setComposeSubmitting(false);
+			}
+		},
+		[
+			user,
+			requireLogin,
+			composeText,
+			composeTags,
+			composeCommunity,
+			isTitleMode,
+			book.abbrev,
+			chapter,
+			selectedVerse,
+			handleNotification,
+			resetCompose,
+		],
+	);
 
-  const handleLike = useCallback(async (id: string) => {
-    if (!user) { requireLogin(); return; }
-    const result = await toggleLikeAction(id);
-    if (!result.ok) {
-      handleNotification("error", "Erro ao curtir.");
-      return;
-    }
-    // The action returns { commentId, likeCount, likedByMe } — only those
-    // two fields change on the affected card.
-    const { likeCount, likedByMe } = result.data;
-    const updater = (prev: CommentData[]) =>
-      prev.map((c) => (c._id === id ? { ...c, likeCount, likedByMe } : c));
-    setComments(updater);
-    setTitleComments(updater);
-  }, [user, requireLogin, handleNotification]);
+	const handleLike = useCallback(
+		async (id: string) => {
+			if (!user) {
+				requireLogin();
+				return;
+			}
+			const result = await toggleLikeAction(id);
+			if (!result.ok) {
+				handleNotification("error", "Erro ao curtir.");
+				return;
+			}
+			// The action returns { commentId, likeCount, likedByMe } — only those
+			// two fields change on the affected card.
+			const { likeCount, likedByMe } = result.data;
+			const updater = (prev: CommentData[]) =>
+				prev.map((c) => (c._id === id ? { ...c, likeCount, likedByMe } : c));
+			setComments(updater);
+			setTitleComments(updater);
+		},
+		[user, requireLogin, handleNotification],
+	);
 
-  const handleReport = useCallback(async (id: string) => {
-    if (!user) { requireLogin(); return; }
-    const ok = await confirm({
-      title: "Reportar este comentário?",
-      description: "Use essa opção apenas para conteúdo abusivo, ofensivo ou fora do tema. A moderação será notificada.",
-      confirmLabel: "Reportar",
-      variant: "danger",
-    });
-    if (!ok) return;
-    const result = await reportCommentAction(id);
-    if (!result.ok) {
-      handleNotification("error", "Erro ao reportar.");
-      return;
-    }
-    handleNotification("info", "Comentário reportado.");
-  }, [user, requireLogin, handleNotification, confirm]);
+	const handleReport = useCallback(
+		async (id: string) => {
+			if (!user) {
+				requireLogin();
+				return;
+			}
+			const ok = await confirm({
+				title: "Reportar este comentário?",
+				description:
+					"Use essa opção apenas para conteúdo abusivo, ofensivo ou fora do tema. A moderação será notificada.",
+				confirmLabel: "Reportar",
+				variant: "danger",
+			});
+			if (!ok) return;
+			const result = await reportCommentAction(id);
+			if (!result.ok) {
+				handleNotification("error", "Erro ao reportar.");
+				return;
+			}
+			handleNotification("info", "Comentário reportado.");
+		},
+		[user, requireLogin, handleNotification, confirm],
+	);
 
-  // Moderator-only: flip the admin-verified badge on a comment without
-  // bouncing to /admin/moderation. Updates both lists optimistically so the
-  // checkmark next to the username refreshes immediately.
-  const handleToggleVerified = useCallback(async (id: string) => {
-    if (!user?.moderator) return;
-    const result = await toggleCommentVerifiedAction(id);
-    if (!result.ok) {
-      handleNotification(
-        "error",
-        result.error === "Forbidden" ? "Sem permissão." : "Erro ao alterar verificação.",
-      );
-      return;
-    }
-    const updated = result.data;
-    const patch = (c: CommentData): CommentData =>
-      c._id === id
-        ? { ...c, verified: updated.verified ?? false, verifiedBy: updated.verifiedBy }
-        : c;
-    setComments((prev) => prev.map(patch));
-    setTitleComments((prev) => prev.map(patch));
-    handleNotification(
-      "success",
-      updated.verified ? "Comentário verificado." : "Verificação removida.",
-    );
-  }, [user, handleNotification]);
+	// Moderator-only: flip the admin-verified badge on a comment without
+	// bouncing to /admin/moderation. Updates both lists optimistically so the
+	// checkmark next to the username refreshes immediately.
+	const handleToggleVerified = useCallback(
+		async (id: string) => {
+			if (!user?.moderator) return;
+			const result = await toggleCommentVerifiedAction(id);
+			if (!result.ok) {
+				handleNotification(
+					"error",
+					result.error === "Forbidden"
+						? "Sem permissão."
+						: "Erro ao alterar verificação.",
+				);
+				return;
+			}
+			const updated = result.data;
+			const patch = (c: CommentData): CommentData =>
+				c._id === id
+					? {
+							...c,
+							verified: updated.verified ?? false,
+							verifiedBy: updated.verifiedBy,
+						}
+					: c;
+			setComments((prev) => prev.map(patch));
+			setTitleComments((prev) => prev.map(patch));
+			handleNotification(
+				"success",
+				updated.verified ? "Comentário verificado." : "Verificação removida.",
+			);
+		},
+		[user, handleNotification],
+	);
 
-  const handleDelete = useCallback(async (id: string) => {
-    if (!user) { requireLogin(); return; }
-    const ok = await confirm({
-      title: "Excluir este comentário?",
-      description: "Esta ação não pode ser desfeita.",
-      confirmLabel: "Excluir",
-      variant: "danger",
-    });
-    if (!ok) return;
-    const result = await deleteCommentAction(id);
-    if (!result.ok) {
-      handleNotification("error", result.error === "Forbidden" ? "Sem permissão." : "Erro ao excluir.");
-      return;
-    }
-    setComments((prev) => prev.filter((c) => c._id !== id));
-    setTitleComments((prev) => prev.filter((c) => c._id !== id));
-    handleNotification("success", "Comentário excluído.");
-  }, [user, requireLogin, handleNotification, confirm]);
+	const handleDelete = useCallback(
+		async (id: string) => {
+			if (!user) {
+				requireLogin();
+				return;
+			}
+			const ok = await confirm({
+				title: "Excluir este comentário?",
+				description: "Esta ação não pode ser desfeita.",
+				confirmLabel: "Excluir",
+				variant: "danger",
+			});
+			if (!ok) return;
+			const result = await deleteCommentAction(id);
+			if (!result.ok) {
+				handleNotification(
+					"error",
+					result.error === "Forbidden" ? "Sem permissão." : "Erro ao excluir.",
+				);
+				return;
+			}
+			setComments((prev) => prev.filter((c) => c._id !== id));
+			setTitleComments((prev) => prev.filter((c) => c._id !== id));
+			handleNotification("success", "Comentário excluído.");
+		},
+		[user, requireLogin, handleNotification, confirm],
+	);
 
-  const startEdit = useCallback((comment: CommentData) => {
-    setEditingComment(comment);
-    setEditText(comment.text);
-    const tagMap: Record<string, boolean> = { devocional: false, exegese: false, pessoal: false, inspirado: false };
-    comment.tags.forEach((t) => { if (t in tagMap) tagMap[t] = true; });
-    setEditTags(tagMap);
-  }, []);
+	const startEdit = useCallback((comment: CommentData) => {
+		setEditingComment(comment);
+		setEditText(comment.text);
+		const tagMap: Record<string, boolean> = {
+			devocional: false,
+			exegese: false,
+			pessoal: false,
+			inspirado: false,
+		};
+		comment.tags.forEach((t) => {
+			if (t in tagMap) tagMap[t] = true;
+		});
+		setEditTags(tagMap);
+	}, []);
 
-  const handleEditSave = useCallback(async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!editingComment) return;
-    if (editText.length < MIN_LEN || editText.length > MAX_LEN) {
-      handleNotification("info", `Comentário deve ter entre ${MIN_LEN} e ${MAX_LEN} caracteres.`);
-      return;
-    }
-    const tagList = Object.entries(editTags).filter(([, v]) => v).map(([k]) => k);
-    const result = await updateCommentAction(editingComment._id, { text: editText, tags: tagList });
-    if (!result.ok) {
-      handleNotification("error", "Erro ao editar.");
-      return;
-    }
-    const updated = result.data as unknown as CommentData;
-    setComments((prev) => prev.map((c) => c._id === editingComment._id ? updated : c));
-    setTitleComments((prev) => prev.map((c) => c._id === editingComment._id ? updated : c));
-    handleNotification("success", "Comentário editado!");
-    setEditingComment(null);
-  }, [editingComment, editText, editTags, handleNotification]);
+	const handleEditSave = useCallback(
+		async (e: React.FormEvent) => {
+			e.preventDefault();
+			if (!editingComment) return;
+			if (editText.length < MIN_LEN || editText.length > MAX_LEN) {
+				handleNotification(
+					"info",
+					`Comentário deve ter entre ${MIN_LEN} e ${MAX_LEN} caracteres.`,
+				);
+				return;
+			}
+			const tagList = Object.entries(editTags)
+				.filter(([, v]) => v)
+				.map(([k]) => k);
+			const result = await updateCommentAction(editingComment._id, {
+				text: editText,
+				tags: tagList,
+			});
+			if (!result.ok) {
+				handleNotification("error", "Erro ao editar.");
+				return;
+			}
+			const updated = result.data as unknown as CommentData;
+			setComments((prev) =>
+				prev.map((c) => (c._id === editingComment._id ? updated : c)),
+			);
+			setTitleComments((prev) =>
+				prev.map((c) => (c._id === editingComment._id ? updated : c)),
+			);
+			handleNotification("success", "Comentário editado!");
+			setEditingComment(null);
+		},
+		[editingComment, editText, editTags, handleNotification],
+	);
 
-  const handleDiscussion = useCallback((id: string, text: string, reference: string) => {
-    if (!user) { requireLogin(); return; }
-    router.push(`/discussion/${book.abbrev}?commentId=${id}&ref=${encodeURIComponent(reference)}&text=${encodeURIComponent(text)}`);
-  }, [user, requireLogin, book.abbrev, router]);
+	const handleDiscussion = useCallback(
+		(id: string, text: string, reference: string) => {
+			if (!user) {
+				requireLogin();
+				return;
+			}
+			router.push(
+				`/discussion/${book.abbrev}?commentId=${id}&ref=${encodeURIComponent(reference)}&text=${encodeURIComponent(text)}`,
+			);
+		},
+		[user, requireLogin, book.abbrev, router],
+	);
 
-  const showSidebar = selectedVerse !== null || isTitleMode;
+	const showSidebar = selectedVerse !== null || isTitleMode;
 
-  // Keyboard navigation: ← / → for chapters, Esc to close the comment
-  // sidebar. Skip when the user is typing in an input/textarea or when a
-  // modifier key is pressed (so browser shortcuts still work).
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return;
-      if (e.key === "Escape" && showSidebar) {
-        e.preventDefault();
-        handleClose();
-      } else if (e.key === "ArrowRight" && nextChapter && !showSidebar) {
-        e.preventDefault();
-        router.push(`/verses/${book.abbrev}/${nextChapter}`);
-      } else if (e.key === "ArrowLeft" && prevChapter && !showSidebar) {
-        e.preventDefault();
-        router.push(`/verses/${book.abbrev}/${prevChapter}`);
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [showSidebar, nextChapter, prevChapter, book.abbrev, router, handleClose]);
+	// Keyboard navigation: ← / → for chapters, Esc to close the comment
+	// sidebar. Skip when the user is typing in an input/textarea or when a
+	// modifier key is pressed (so browser shortcuts still work).
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (e.metaKey || e.ctrlKey || e.altKey) return;
+			const target = e.target as HTMLElement | null;
+			const tag = target?.tagName;
+			if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable)
+				return;
+			if (e.key === "Escape" && showSidebar) {
+				e.preventDefault();
+				handleClose();
+			} else if (e.key === "ArrowRight" && nextChapter && !showSidebar) {
+				e.preventDefault();
+				router.push(`/verses/${book.abbrev}/${nextChapter}`);
+			} else if (e.key === "ArrowLeft" && prevChapter && !showSidebar) {
+				e.preventDefault();
+				router.push(`/verses/${book.abbrev}/${prevChapter}`);
+			}
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [showSidebar, nextChapter, prevChapter, book.abbrev, router, handleClose]);
 
-  // The comment panel is a focused full-screen task on mobile — hide the
-  // global bottom tab bar while it is open (see globals.css .bc-hide-tabbar).
-  useEffect(() => {
-    if (!showSidebar) return;
-    document.body.classList.add("bc-hide-tabbar");
-    return () => document.body.classList.remove("bc-hide-tabbar");
-  }, [showSidebar]);
+	// The comment panel is a focused full-screen task on mobile — hide the
+	// global bottom tab bar while it is open (see globals.css .bc-hide-tabbar).
+	useEffect(() => {
+		if (!showSidebar) return;
+		document.body.classList.add("bc-hide-tabbar");
+		return () => document.body.classList.remove("bc-hide-tabbar");
+	}, [showSidebar]);
 
-  // Swipe-to-navigate (touch only, mobile). Threshold ~60px horizontal,
-  // ignored if vertical movement dominates (avoids hijacking scrolls)
-  // or if the sidebar is open (would conflict with closing the drawer).
-  const touchStart = useRef<{ x: number; y: number } | null>(null);
-  const onTouchStart = useCallback((e: React.TouchEvent) => {
-    if (showSidebar) return;
-    const t = e.touches[0];
-    touchStart.current = { x: t.clientX, y: t.clientY };
-  }, [showSidebar]);
-  const onTouchEnd = useCallback((e: React.TouchEvent) => {
-    const start = touchStart.current;
-    touchStart.current = null;
-    if (!start) return;
-    const t = e.changedTouches[0];
-    const dx = t.clientX - start.x;
-    const dy = t.clientY - start.y;
-    if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return;
-    if (dx < 0 && nextChapter) router.push(`/verses/${book.abbrev}/${nextChapter}`);
-    else if (dx > 0 && prevChapter) router.push(`/verses/${book.abbrev}/${prevChapter}`);
-  }, [book.abbrev, nextChapter, prevChapter, router]);
+	// Swipe-to-navigate (touch only, mobile). Threshold ~60px horizontal,
+	// ignored if vertical movement dominates (avoids hijacking scrolls)
+	// or if the sidebar is open (would conflict with closing the drawer).
+	const touchStart = useRef<{ x: number; y: number } | null>(null);
+	const onTouchStart = useCallback(
+		(e: React.TouchEvent) => {
+			if (showSidebar) return;
+			const t = e.touches[0];
+			touchStart.current = { x: t.clientX, y: t.clientY };
+		},
+		[showSidebar],
+	);
+	const onTouchEnd = useCallback(
+		(e: React.TouchEvent) => {
+			const start = touchStart.current;
+			touchStart.current = null;
+			if (!start) return;
+			const t = e.changedTouches[0];
+			const dx = t.clientX - start.x;
+			const dy = t.clientY - start.y;
+			if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return;
+			if (dx < 0 && nextChapter)
+				router.push(`/verses/${book.abbrev}/${nextChapter}`);
+			else if (dx > 0 && prevChapter)
+				router.push(`/verses/${book.abbrev}/${prevChapter}`);
+		},
+		[book.abbrev, nextChapter, prevChapter, router],
+	);
 
-  const sidebarTitle = isTitleMode
-    ? `${book.name} ${chapter}`
-    : selectedVerse
-      ? `${book.abbrev.charAt(0).toUpperCase() + book.abbrev.slice(1)} ${chapter}:${selectedVerse.verseNumber}`
-      : "";
+	const sidebarTitle = isTitleMode
+		? `${book.name} ${chapter}`
+		: selectedVerse
+			? `${book.abbrev.charAt(0).toUpperCase() + book.abbrev.slice(1)} ${chapter}:${selectedVerse.verseNumber}`
+			: "";
 
-  const sidebarRef2 = sidebarRef;
+	const sidebarRef2 = sidebarRef;
 
-  return (
-    <div className="min-h-screen flex flex-col bg-[#f9f9f7] dark:bg-slate-950">
+	return (
+		<div className="min-h-screen flex flex-col bg-[#f9f9f7] dark:bg-slate-950">
+			<AppHeader
+				user={user}
+				loginCallbackUrl={`/verses/${book.abbrev}/${chapter}`}
+				trailing={<FontSizeControl />}
+			/>
 
-      <AppHeader
-        user={user}
-        loginCallbackUrl={`/verses/${book.abbrev}/${chapter}`}
-        trailing={<FontSizeControl />}
-      />
+			<div className="flex flex-1 relative min-h-0">
+				<main
+					id="main-content"
+					onTouchStart={onTouchStart}
+					onTouchEnd={onTouchEnd}
+					className={`flex-1 overflow-y-auto transition-[padding] duration-200 ${showSidebar ? "md:pr-[420px]" : ""}`}
+				>
+					<div className="max-w-[680px] mx-auto px-6 py-10">
+						<div className="flex items-center gap-4 mb-2 text-sm text-gray-400 dark:text-gray-500">
+							<Link
+								href="/home"
+								className="hover:text-blue-600 dark:hover:text-blue-400 transition"
+							>
+								← Livros
+							</Link>
+							{prevChapter && (
+								<Link
+									href={`/verses/${book.abbrev}/${prevChapter}`}
+									className="hover:text-blue-600 dark:hover:text-blue-400 transition"
+								>
+									Cap. {prevChapter}
+								</Link>
+							)}
+							<span className="flex-1" />
+							{nextChapter && (
+								<Link
+									href={`/verses/${book.abbrev}/${nextChapter}`}
+									className="hover:text-blue-600 dark:hover:text-blue-400 transition"
+								>
+									Cap. {nextChapter}
+								</Link>
+							)}
+						</div>
 
+						<div className="flex items-center justify-center gap-3 mt-6 mb-3">
+							<button
+								type="button"
+								onClick={openTitlePanel}
+								className="flex items-center gap-2 hover:opacity-80 transition"
+							>
+								<h1 className="font-serif font-bold text-slate-800 dark:text-slate-100 tracking-[1.9px] uppercase text-[clamp(24px,4vw,38px)]">
+									{book.name} {chapter}
+								</h1>
+								<svg
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="#94a3b8"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<polyline points="6 9 12 15 18 9" />
+								</svg>
+							</button>
+						</div>
 
-      <div className="flex flex-1 relative min-h-0">
-        <main
-          id="main-content"
-          onTouchStart={onTouchStart}
-          onTouchEnd={onTouchEnd}
-          className={`flex-1 overflow-y-auto transition-[padding] duration-200 ${showSidebar ? "md:pr-[420px]" : ""}`}
-        >
-          <div className="max-w-[680px] mx-auto px-6 py-10">
-            <div className="flex items-center gap-4 mb-2 text-sm text-gray-400 dark:text-gray-500">
-              <Link href="/home" className="hover:text-blue-600 dark:hover:text-blue-400 transition">← Livros</Link>
-              {prevChapter && (
-                <Link href={`/verses/${book.abbrev}/${prevChapter}`} className="hover:text-blue-600 dark:hover:text-blue-400 transition">
-                  Cap. {prevChapter}
-                </Link>
-              )}
-              <span className="flex-1" />
-              {nextChapter && (
-                <Link href={`/verses/${book.abbrev}/${nextChapter}`} className="hover:text-blue-600 dark:hover:text-blue-400 transition">
-                  Cap. {nextChapter}
-                </Link>
-              )}
-            </div>
+						<div className="flex items-center justify-center mb-6">
+							<MarkAsReadButton
+								abbrev={book.abbrev}
+								chapter={chapter}
+								initialRead={alreadyRead}
+								enabled={!!user}
+							/>
+						</div>
 
-            <div className="flex items-center justify-center gap-3 mt-6 mb-3">
-              <button
-                type="button"
-                onClick={openTitlePanel}
-                className="flex items-center gap-2 hover:opacity-80 transition"
-              >
-                <h1
-                  className="font-serif font-bold text-slate-800 dark:text-slate-100 tracking-[1.9px] uppercase text-[clamp(24px,4vw,38px)]"
-                >
-                  {book.name} {chapter}
-                </h1>
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="6 9 12 15 18 9" />
-                </svg>
-              </button>
-            </div>
-
-            <div className="flex items-center justify-center mb-6">
-              <MarkAsReadButton
-                abbrev={book.abbrev}
-                chapter={chapter}
-                initialRead={alreadyRead}
-                enabled={!!user}
-              />
-            </div>
-
-            {/* Community filter chips — only renders for users in at least
+						{/* Community filter chips — only renders for users in at least
                 one community. Geral is always available; clicking it toggles
                 showing the unmarked feed alongside the chosen communities. */}
-            {user && userCommunities.length > 0 && (() => {
-              const allChips = [GENERAL_BUCKET, ...userCommunities.map((c) => c.slug)];
-              // "null" means "all on" by default — first click switches to an
-              // explicit list (every chip minus the clicked one), so the
-              // visual stays consistent: tapping an active chip turns it off.
-              const handleChipClick = (slug: string) => {
-                if (communityFilter.selected === null) {
-                  communityFilter.setSelected(allChips.filter((s) => s !== slug));
-                } else {
-                  communityFilter.toggle(slug);
-                }
-              };
-              return (
-                <div
-                  data-testid="community-filter-row"
-                  className="flex flex-wrap items-center gap-2 mb-5 text-[12px]"
-                >
-                  <span className="text-slate-500 dark:text-slate-400 font-medium">
-                    Mostrar:
-                  </span>
-                  {[{ slug: GENERAL_BUCKET, name: "Geral" }, ...userCommunities].map(
-                    (c) => {
-                      const isActive =
-                        communityFilter.selected === null
-                          ? true
-                          : communityFilter.selected.includes(c.slug);
-                      return (
-                        <button
-                          key={c.slug}
-                          type="button"
-                          onClick={() => handleChipClick(c.slug)}
-                          data-testid={`community-filter-chip-${c.slug}`}
-                          data-active={isActive ? "true" : "false"}
-                          className={`px-2.5 py-1 rounded-full border transition font-medium ${
-                            isActive
-                              ? "bg-brand text-white border-brand"
-                              : "bg-transparent text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-brand hover:text-brand"
-                          }`}
-                        >
-                          {c.slug === GENERAL_BUCKET ? "Geral" : `/${c.slug}`}
-                        </button>
-                      );
-                    },
-                  )}
-                  {communityFilter.selected !== null && (
-                    <button
-                      type="button"
-                      onClick={() => communityFilter.setSelected(null)}
-                      data-testid="community-filter-reset"
-                      className="ml-auto text-[11px] text-slate-400 dark:text-slate-500 hover:text-brand underline"
-                    >
-                      limpar filtro
-                    </button>
-                  )}
-                </div>
-              );
-            })()}
+						{user &&
+							userCommunities.length > 0 &&
+							(() => {
+								const allChips = [
+									GENERAL_BUCKET,
+									...userCommunities.map((c) => c.slug),
+								];
+								// "null" means "all on" by default — first click switches to an
+								// explicit list (every chip minus the clicked one), so the
+								// visual stays consistent: tapping an active chip turns it off.
+								const handleChipClick = (slug: string) => {
+									if (communityFilter.selected === null) {
+										communityFilter.setSelected(
+											allChips.filter((s) => s !== slug),
+										);
+									} else {
+										communityFilter.toggle(slug);
+									}
+								};
+								return (
+									<div
+										data-testid="community-filter-row"
+										className="flex flex-wrap items-center gap-2 mb-5 text-[12px]"
+									>
+										<span className="text-slate-500 dark:text-slate-400 font-medium">
+											Mostrar:
+										</span>
+										{[
+											{ slug: GENERAL_BUCKET, name: "Geral" },
+											...userCommunities,
+										].map((c) => {
+											const isActive =
+												communityFilter.selected === null
+													? true
+													: communityFilter.selected.includes(c.slug);
+											return (
+												<button
+													key={c.slug}
+													type="button"
+													onClick={() => handleChipClick(c.slug)}
+													data-testid={`community-filter-chip-${c.slug}`}
+													data-active={isActive ? "true" : "false"}
+													className={`px-2.5 py-1 rounded-full border transition font-medium ${
+														isActive
+															? "bg-brand text-white border-brand"
+															: "bg-transparent text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-brand hover:text-brand"
+													}`}
+												>
+													{c.slug === GENERAL_BUCKET ? "Geral" : `/${c.slug}`}
+												</button>
+											);
+										})}
+										{communityFilter.selected !== null && (
+											<button
+												type="button"
+												onClick={() => communityFilter.setSelected(null)}
+												data-testid="community-filter-reset"
+												className="ml-auto text-[11px] text-slate-400 dark:text-slate-500 hover:text-brand underline"
+											>
+												limpar filtro
+											</button>
+										)}
+									</div>
+								);
+							})()}
 
-            {(titleCount > 0 || isTitleMode) && (
-              <button
-                type="button"
-                onClick={openTitlePanel}
-                className="flex items-center gap-3 w-full mb-6 px-4 py-2.5 rounded-r-md text-left transition hover:bg-black/5 bg-black/[0.02] border-l-4 border-solid"
-                style={{
-                  borderLeftColor: isTitleMode ? "#137ddb" : "rgba(0,0,0,0)"
-                }}
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#64748b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
-                </svg>
-                <span className="text-[14px] text-slate-500 dark:text-slate-400 flex-1">Visão Geral do Capítulo</span>
-                {titleCount > 0 && (
-                  <span className="bg-brand text-white text-[11px] font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center">
-                    {titleCount}
-                  </span>
-                )}
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-              </button>
-            )}
+						{(titleCount > 0 || isTitleMode) && (
+							<button
+								type="button"
+								onClick={openTitlePanel}
+								className="flex items-center gap-3 w-full mb-6 px-4 py-2.5 rounded-r-md text-left transition hover:bg-black/5 bg-black/[0.02] border-l-4 border-solid"
+								style={{
+									borderLeftColor: isTitleMode ? "#137ddb" : "rgba(0,0,0,0)",
+								}}
+							>
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="#64748b"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<circle cx="12" cy="12" r="10" />
+									<line x1="12" y1="8" x2="12" y2="12" />
+									<line x1="12" y1="16" x2="12.01" y2="16" />
+								</svg>
+								<span className="text-[14px] text-slate-500 dark:text-slate-400 flex-1">
+									Visão Geral do Capítulo
+								</span>
+								{titleCount > 0 && (
+									<span className="bg-brand text-white text-[11px] font-bold px-2 py-0.5 rounded-full min-w-[22px] text-center">
+										{titleCount}
+									</span>
+								)}
+								<svg
+									width="13"
+									height="13"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="#94a3b8"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<polyline points="9 18 15 12 9 6" />
+								</svg>
+							</button>
+						)}
 
-            <div className="relative">
-              <div
-                className="hidden md:block absolute right-full top-0 -mr-5 z-10 text-right font-serif select-none pointer-events-none text-[80px] leading-[80px] font-black text-slate-800 dark:text-slate-100 opacity-80"
-              >
-                {chapter}
-              </div>
+						<div className="relative">
+							<div className="hidden md:block absolute right-full top-0 -mr-5 z-10 text-right font-serif select-none pointer-events-none text-[80px] leading-[80px] font-black text-slate-800 dark:text-slate-100 opacity-80">
+								{chapter}
+							</div>
 
-              <ul className="space-y-[2px]">
-                {verses.map((verse, idx) => {
-                  const count = verse._id ? (countMap[verse._id] ?? 0) : 0;
-                  const isSelected = selectedVerse?._id === verse._id && !isTitleMode;
-                  return (
-                    <li key={verse._id} id={String(verse.verseNumber)} data-tour={idx === 0 ? "verse-first" : undefined} className="group relative">
-                      <button
-                        type="button"
-                        onClick={() => openVersePanel(verse)}
-                        className={`flex items-start gap-2 md:gap-3 w-full text-left rounded-r-[4px] transition border-l-4 border-solid pt-3 pr-2.5 pl-1.5 md:pl-3 md:pt-2 md:pb-2 hover:bg-[rgba(19,125,219,0.07)] dark:hover:bg-[rgba(19,125,219,0.16)] active:bg-[rgba(19,125,219,0.12)] dark:active:bg-[rgba(19,125,219,0.22)] min-h-[44px] ${count > 0 ? "pb-7 md:pb-2" : "pb-3"}`}
-                        style={{
-                          borderLeftColor: isSelected ? "#137ddb" : "transparent",
-                          background: isSelected ? "rgba(19,125,219,0.04)" : undefined
-                        }}
-                      >
-                        <span
-                          className="font-sans font-bold text-[14px] md:text-[13px] w-5 md:w-5 flex-shrink-0 text-right mt-[2px] transition"
-                          style={{ color: isSelected ? "#137ddb" : "#94a3b8" }}
-                        >
-                          {verse.verseNumber}
-                        </span>
-                        <span
-                          data-testid="verse-text"
-                          className="flex-1 font-serif leading-[1.85] transition text-[#1a1a1a] dark:text-slate-100"
-                          style={{ fontSize: "17px" }}
-                        >
-                          {verse.text}
-                        </span>
-                        {/* Desktop: count badge inline on the right; mobile gets the
+							<ul className="space-y-[2px]">
+								{verses.map((verse, idx) => {
+									const count = verse._id ? (countMap[verse._id] ?? 0) : 0;
+									const isSelected =
+										selectedVerse?._id === verse._id && !isTitleMode;
+									return (
+										<li
+											key={verse._id}
+											id={String(verse.verseNumber)}
+											data-tour={idx === 0 ? "verse-first" : undefined}
+											className="group relative"
+										>
+											<button
+												type="button"
+												onClick={() => openVersePanel(verse)}
+												className={`flex items-start gap-2 md:gap-3 w-full text-left rounded-r-[4px] transition border-l-4 border-solid pt-3 pr-2.5 pl-1.5 md:pl-3 md:pt-2 md:pb-2 hover:bg-[rgba(19,125,219,0.07)] dark:hover:bg-[rgba(19,125,219,0.16)] active:bg-[rgba(19,125,219,0.12)] dark:active:bg-[rgba(19,125,219,0.22)] min-h-[44px] ${count > 0 ? "pb-7 md:pb-2" : "pb-3"}`}
+												style={{
+													borderLeftColor: isSelected
+														? "#137ddb"
+														: "transparent",
+													background: isSelected
+														? "rgba(19,125,219,0.04)"
+														: undefined,
+												}}
+											>
+												<span
+													className="font-sans font-bold text-[14px] md:text-[13px] w-5 md:w-5 flex-shrink-0 text-right mt-[2px] transition"
+													style={{ color: isSelected ? "#137ddb" : "#94a3b8" }}
+												>
+													{verse.verseNumber}
+												</span>
+												<span
+													data-testid="verse-text"
+													className="flex-1 font-serif leading-[1.85] transition text-[#1a1a1a] dark:text-slate-100"
+													style={{ fontSize: "17px" }}
+												>
+													{verse.text}
+												</span>
+												{/* Desktop: count badge inline on the right; mobile gets the
                             badge anchored to the bottom-right of the verse instead so it
                             doesn't collide with the copy icon at top-right. */}
-                        {count > 0 && (
-                          <span className="hidden md:flex flex-shrink-0 items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand">
-                            <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-                            </svg>
-                            <span className="font-bold text-[11px] text-white leading-[11px]">{count}</span>
-                          </span>
-                        )}
-                      </button>
-                      {count > 0 && (
-                        <span
-                          aria-hidden="true"
-                          className="md:hidden absolute right-2 bottom-1.5 flex items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand pointer-events-none"
-                        >
-                          <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-                          </svg>
-                          <span className="font-bold text-[11px] text-white leading-[11px]">{count}</span>
-                        </span>
-                      )}
-                      <div className="absolute right-[-10px] top-1 rounded-md bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm md:opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity opacity-60">
-                        <CopyVerseButton
-                          verse={{
-                            abbrev: book.abbrev,
-                            chapter,
-                            verseNumber: verse.verseNumber,
-                            text: verse.text,
-                          }}
-                          label=""
-                          className="!px-1.5 !py-1"
-                        />
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
+												{count > 0 && (
+													<span className="hidden md:flex flex-shrink-0 items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand">
+														<svg
+															width="9"
+															height="9"
+															viewBox="0 0 24 24"
+															fill="none"
+															stroke="#fff"
+															strokeWidth="2.5"
+															strokeLinecap="round"
+															strokeLinejoin="round"
+														>
+															<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+														</svg>
+														<span className="font-bold text-[11px] text-white leading-[11px]">
+															{count}
+														</span>
+													</span>
+												)}
+											</button>
+											{count > 0 && (
+												<span
+													aria-hidden="true"
+													className="md:hidden absolute right-2 bottom-1.5 flex items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand pointer-events-none"
+												>
+													<svg
+														width="9"
+														height="9"
+														viewBox="0 0 24 24"
+														fill="none"
+														stroke="#fff"
+														strokeWidth="2.5"
+														strokeLinecap="round"
+														strokeLinejoin="round"
+													>
+														<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+													</svg>
+													<span className="font-bold text-[11px] text-white leading-[11px]">
+														{count}
+													</span>
+												</span>
+											)}
+											<div className="absolute right-[-10px] top-1 rounded-md bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm md:opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity opacity-60">
+												<CopyVerseButton
+													verse={{
+														abbrev: book.abbrev,
+														chapter,
+														verseNumber: verse.verseNumber,
+														text: verse.text,
+													}}
+													label=""
+													className="!px-1.5 !py-1"
+												/>
+											</div>
+										</li>
+									);
+								})}
+							</ul>
+						</div>
 
-            <div className="mt-10 flex justify-between">
-              {prevChapter && (
-                <Link href={`/verses/${book.abbrev}/${prevChapter}`} className="text-sm px-4 py-2 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 transition text-gray-600 dark:text-slate-300">
-                  ← Capítulo {prevChapter}
-                </Link>
-              )}
-              {nextChapter && (
-                <Link href={`/verses/${book.abbrev}/${nextChapter}`} className="text-sm px-4 py-2 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 transition text-gray-600 dark:text-slate-300 ml-auto">
-                  Capítulo {nextChapter} →
-                </Link>
-              )}
-            </div>
-          </div>
-        </main>
+						<div className="mt-10 flex justify-between">
+							{prevChapter && (
+								<Link
+									href={`/verses/${book.abbrev}/${prevChapter}`}
+									className="text-sm px-4 py-2 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 transition text-gray-600 dark:text-slate-300"
+								>
+									← Capítulo {prevChapter}
+								</Link>
+							)}
+							{nextChapter && (
+								<Link
+									href={`/verses/${book.abbrev}/${nextChapter}`}
+									className="text-sm px-4 py-2 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 transition text-gray-600 dark:text-slate-300 ml-auto"
+								>
+									Capítulo {nextChapter} →
+								</Link>
+							)}
+						</div>
+					</div>
+				</main>
 
-        {showSidebar && (
-          <aside
-            ref={sidebarRef2}
-            className="fixed top-[68px] left-0 right-0 bottom-0 md:inset-auto md:right-0 bg-white dark:bg-slate-900 md:border-l border-slate-200 dark:border-slate-700 z-30 flex flex-col md:w-[420px] md:top-[68px] md:h-[calc(100vh-68px)]"
-          >
-            <div className="border-b border-slate-200 dark:border-slate-700 px-5 py-3.5 flex items-center gap-3">
-              <div className="flex-1 min-w-0">
-                <p className="text-[10px] font-bold tracking-widest text-slate-400 dark:text-slate-500 uppercase">Comentários</p>
-                <div className="flex items-center gap-2 mt-0.5 min-w-0">
-                  <span className="text-[13px] font-semibold text-slate-700 dark:text-slate-200 truncate">{sidebarTitle}</span>
-                  <span className="bg-[rgba(19,125,219,0.09)] text-brand text-[11px] font-semibold rounded-[10px] min-w-[21px] h-[18.5px] inline-flex items-center justify-center px-[7px]">
-                    {activeComments.length}
-                  </span>
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => {
-                  if (!user) { requireLogin(); return; }
-                  if (composing) resetCompose();
-                  else setComposing(true);
-                }}
-                className="flex items-center gap-[5px] h-[30.667px] px-[11px] border-[1.333px] border-brand rounded-md bg-transparent text-brand text-xs font-semibold cursor-pointer whitespace-nowrap"
-              >
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-                </svg>
-                Comentar
-              </button>
-              <button
-                type="button"
-                onClick={handleClose}
-                aria-label="Fechar comentários"
-                className="flex-shrink-0 flex items-center justify-center w-9 h-9 -mr-1.5 rounded-md text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-                </svg>
-              </button>
-            </div>
+				{showSidebar && (
+					<aside
+						ref={sidebarRef2}
+						className="fixed top-[68px] left-0 right-0 bottom-0 md:inset-auto md:right-0 bg-white dark:bg-slate-900 md:border-l border-slate-200 dark:border-slate-700 z-30 flex flex-col md:w-[420px] md:top-[68px] md:h-[calc(100vh-68px)]"
+					>
+						<div className="border-b border-slate-200 dark:border-slate-700 px-5 py-3.5 flex items-center gap-3">
+							<div className="flex-1 min-w-0">
+								<p className="text-[10px] font-bold tracking-widest text-slate-400 dark:text-slate-500 uppercase">
+									Comentários
+								</p>
+								<div className="flex items-center gap-2 mt-0.5 min-w-0">
+									<span className="text-[13px] font-semibold text-slate-700 dark:text-slate-200 truncate">
+										{sidebarTitle}
+									</span>
+									<span className="bg-[rgba(19,125,219,0.09)] text-brand text-[11px] font-semibold rounded-[10px] min-w-[21px] h-[18.5px] inline-flex items-center justify-center px-[7px]">
+										{activeComments.length}
+									</span>
+								</div>
+							</div>
+							<button
+								type="button"
+								onClick={() => {
+									if (!user) {
+										requireLogin();
+										return;
+									}
+									if (composing) resetCompose();
+									else setComposing(true);
+								}}
+								className="flex items-center gap-[5px] h-[30.667px] px-[11px] border-[1.333px] border-brand rounded-md bg-transparent text-brand text-xs font-semibold cursor-pointer whitespace-nowrap"
+							>
+								<svg
+									width="11"
+									height="11"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2.5"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<line x1="12" y1="5" x2="12" y2="19" />
+									<line x1="5" y1="12" x2="19" y2="12" />
+								</svg>
+								Comentar
+							</button>
+							<button
+								type="button"
+								onClick={handleClose}
+								aria-label="Fechar comentários"
+								className="flex-shrink-0 flex items-center justify-center w-9 h-9 -mr-1.5 rounded-md text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
+							>
+								<svg
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<line x1="18" y1="6" x2="6" y2="18" />
+									<line x1="6" y1="6" x2="18" y2="18" />
+								</svg>
+							</button>
+						</div>
 
-            <div className="flex-1 overflow-y-auto">
-              {composing && (
-                <div className="px-6 pt-4 pb-5">
-                  {/* Composer card */}
-                  <div className="bg-white dark:bg-slate-900 border border-[#d1d9e8] dark:border-slate-700 rounded-[10px] shadow-[0px_4px_20px_0px_rgba(19,125,219,0.10)] overflow-hidden">
-                    {/* Header bar: "Comentando em Ref [Alterar]" */}
-                    <div className="bg-[rgba(26,54,93,0.04)] dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 flex items-center px-4 pt-[11px] pb-[10px] gap-1 min-h-[41.167px]">
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#64748b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0">
-                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
-                      </svg>
-                      <span className="font-normal text-xs text-slate-500 dark:text-slate-400 ml-1.5">Comentando em</span>
-                      <span className="font-bold text-xs text-slate-800 dark:text-slate-100 ml-1">{sidebarTitle}</span>
-                      {selectedVerse && !isTitleMode && (
-                        <button
-                          type="button"
-                          onClick={() => openVersePanel(selectedVerse)}
-                          className="font-medium text-[11px] text-tag-exegese bg-transparent border-none cursor-pointer ml-2 underline"
-                        >
-                          Alterar
-                        </button>
-                      )}
-                    </div>
+						<div className="flex-1 overflow-y-auto">
+							{composing && (
+								<div className="px-6 pt-4 pb-5">
+									{/* Composer card */}
+									<div className="bg-white dark:bg-slate-900 border border-[#d1d9e8] dark:border-slate-700 rounded-[10px] shadow-[0px_4px_20px_0px_rgba(19,125,219,0.10)] overflow-hidden">
+										{/* Header bar: "Comentando em Ref [Alterar]" */}
+										<div className="bg-[rgba(26,54,93,0.04)] dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 flex items-center px-4 pt-[11px] pb-[10px] gap-1 min-h-[41.167px]">
+											<svg
+												width="13"
+												height="13"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="#64748b"
+												strokeWidth="2"
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												className="flex-shrink-0"
+											>
+												<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+												<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+											</svg>
+											<span className="font-normal text-xs text-slate-500 dark:text-slate-400 ml-1.5">
+												Comentando em
+											</span>
+											<span className="font-bold text-xs text-slate-800 dark:text-slate-100 ml-1">
+												{sidebarTitle}
+											</span>
+											{selectedVerse && !isTitleMode && (
+												<button
+													type="button"
+													onClick={() => openVersePanel(selectedVerse)}
+													className="font-medium text-[11px] text-tag-exegese bg-transparent border-none cursor-pointer ml-2 underline"
+												>
+													Alterar
+												</button>
+											)}
+										</div>
 
-                    {/* Verse quote */}
-                    {selectedVerse && !isTitleMode && (
-                      <div className="mt-3 mx-4 bg-slate-50 dark:bg-slate-800 border-l-[2.667px] border-solid border-slate-300 dark:border-slate-600 rounded-r-md py-[9px] px-3">
-                        <p className="text-[13px] text-slate-600 dark:text-slate-300 leading-5 m-0">
-                          {selectedVerse.verseNumber}. {selectedVerse.text}
-                        </p>
-                      </div>
-                    )}
+										{/* Verse quote */}
+										{selectedVerse && !isTitleMode && (
+											<div className="mt-3 mx-4 bg-slate-50 dark:bg-slate-800 border-l-[2.667px] border-solid border-slate-300 dark:border-slate-600 rounded-r-md py-[9px] px-3">
+												<p className="text-[13px] text-slate-600 dark:text-slate-300 leading-5 m-0">
+													{selectedVerse.verseNumber}. {selectedVerse.text}
+												</p>
+											</div>
+										)}
 
-                    {/* Postar em — comunidade do usuário ou geral */}
-                    {userCommunities.length > 0 && (
-                      <div className="pt-3 px-4">
-                        <label className="block text-[11px] font-medium text-slate-500 dark:text-slate-400 mb-1">
-                          Postar em
-                        </label>
-                        <select
-                          value={composeCommunity}
-                          onChange={(e) => setComposeCommunity(e.target.value)}
-                          data-testid="compose-community-select"
-                          className="w-full h-9 px-3 rounded-[7px] border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-[13px] text-slate-700 dark:text-slate-200 cursor-pointer"
-                        >
-                          <option value="">Geral</option>
-                          {userCommunities.map((c) => (
-                            <option key={c.slug} value={c.slug}>
-                              /{c.slug} — {c.name}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    )}
+										{/* Postar em — comunidade do usuário ou geral */}
+										{userCommunities.length > 0 && (
+											<div className="pt-3 px-4">
+												<label className="block text-[11px] font-medium text-slate-500 dark:text-slate-400 mb-1">
+													Postar em
+												</label>
+												<select
+													value={composeCommunity}
+													onChange={(e) => setComposeCommunity(e.target.value)}
+													data-testid="compose-community-select"
+													className="w-full h-9 px-3 rounded-[7px] border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-[13px] text-slate-700 dark:text-slate-200 cursor-pointer"
+												>
+													<option value="">Geral</option>
+													{userCommunities.map((c) => (
+														<option key={c.slug} value={c.slug}>
+															/{c.slug} — {c.name}
+														</option>
+													))}
+												</select>
+											</div>
+										)}
 
-                    {/* Type CategoryCards */}
-                    <div className="pt-3 px-4">
-                      <div className="grid grid-cols-2 gap-1.5">
-                        {TAG_ORDER.map((tag) => {
-                          const meta = TAG_META[tag];
-                          const active = composeTags[tag];
-                          return (
-                            <button
-                              key={tag}
-                              type="button"
-                              onClick={() => setComposeTags((prev) => ({ ...prev, [tag]: !prev[tag] }))}
-                              aria-pressed={active}
-                              className="flex items-center gap-2 h-[41.5px] px-[14px] rounded-[7px] border-2 border-solid cursor-pointer"
-                              style={{
-                                borderColor: active ? meta.border : "#e2e8f0",
-                                background: active ? meta.bg : "transparent"
-                              }}
-                            >
-                              <span
-                                className="flex-shrink-0 inline-flex"
-                                style={{ color: meta.color }}
-                              >
-                                <TagIcon name={meta.icon} width={16} height={16} />
-                              </span>
-                              <span className="font-normal text-[13px]" style={{ color: active ? meta.color : "#64748b" }}>{meta.label}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
+										{/* Type CategoryCards */}
+										<div className="pt-3 px-4">
+											<div className="grid grid-cols-2 gap-1.5">
+												{TAG_ORDER.map((tag) => {
+													const meta = TAG_META[tag];
+													const active = composeTags[tag];
+													return (
+														<button
+															key={tag}
+															type="button"
+															onClick={() =>
+																setComposeTags((prev) => ({
+																	...prev,
+																	[tag]: !prev[tag],
+																}))
+															}
+															aria-pressed={active}
+															className="flex items-center gap-2 h-[41.5px] px-[14px] rounded-[7px] border-2 border-solid cursor-pointer"
+															style={{
+																borderColor: active ? meta.border : "#e2e8f0",
+																background: active ? meta.bg : "transparent",
+															}}
+														>
+															<span
+																className="flex-shrink-0 inline-flex"
+																style={{ color: meta.color }}
+															>
+																<TagIcon
+																	name={meta.icon}
+																	width={16}
+																	height={16}
+																/>
+															</span>
+															<span
+																className="font-normal text-[13px]"
+																style={{
+																	color: active ? meta.color : "#64748b",
+																}}
+															>
+																{meta.label}
+															</span>
+														</button>
+													);
+												})}
+											</div>
+										</div>
 
-                    {/* Textarea */}
-                    <div className="pt-3 px-4 overflow-hidden">
-                      <form onSubmit={handleCompose}>
-                        <textarea
-                          value={composeText}
-                          onChange={(e) => {
-                            let v = e.target.value;
-                            if (v.slice(-2) === "  ") v = v.slice(0, -1);
-                            setComposeText(v);
-                          }}
-                          placeholder="Escreva seu comentário aqui…"
-                          rows={4}
-                          className="w-full border-none outline-none resize-none text-[14px] text-[rgba(26,26,26,0.85)] dark:text-slate-100 leading-[25.2px] bg-transparent box-border"
-                        />
-                        {/* Footer */}
-                        <div className="border-t border-slate-100 dark:border-slate-800 flex items-center gap-2 pt-3 pb-4 mt-1">
-                          <button
-                            type="button"
-                            onClick={resetCompose}
-                            className="font-medium text-[13px] text-slate-400 dark:text-slate-500 bg-transparent border-none cursor-pointer"
-                          >
-                            Cancelar
-                          </button>
-                          {(() => {
-                            const len = composeText.length;
-                            const tooShort = len < MIN_LEN;
-                            const tooLong = len > MAX_LEN;
-                            const target = tooShort ? MIN_LEN : MAX_LEN;
-                            // Color encodes the state at a glance — amber while
-                            // the user can't yet publish, red when over the cap.
-                            const color = tooLong
-                              ? "text-red-500 dark:text-red-400"
-                              : tooShort
-                                ? "text-amber-500 dark:text-amber-400"
-                                : "text-slate-400 dark:text-slate-500";
-                            return (
-                              <span className={`ml-auto mr-3 text-[11px] font-medium ${color}`}>
-                                {len}/{target} caracteres
-                              </span>
-                            );
-                          })()}
-                          <button
-                            type="submit"
-                            disabled={composeText.length < MIN_LEN || composeText.length > MAX_LEN || composeSubmitting}
-                            className="h-9 px-4 rounded-[7px] border-none font-semibold text-[13px] whitespace-nowrap"
-                            style={{
-                              cursor: composeText.length >= MIN_LEN ? "pointer" : "default",
-                              background: composeText.length >= MIN_LEN && !composeSubmitting ? "#137ddb" : "#f1f5f9",
-                              color: composeText.length >= MIN_LEN && !composeSubmitting ? "#fff" : "#a0aec0"
-                            }}
-                          >
-                            {composeSubmitting ? "Publicando…" : "Publicar comentário"}
-                          </button>
-                        </div>
-                      </form>
-                    </div>
-                  </div>
-                </div>
-              )}
+										{/* Textarea */}
+										<div className="pt-3 px-4 overflow-hidden">
+											<form onSubmit={handleCompose}>
+												<textarea
+													value={composeText}
+													onChange={(e) => {
+														let v = e.target.value;
+														if (v.slice(-2) === "  ") v = v.slice(0, -1);
+														setComposeText(v);
+													}}
+													placeholder="Escreva seu comentário aqui…"
+													rows={4}
+													className="w-full border-none outline-none resize-none text-[14px] text-[rgba(26,26,26,0.85)] dark:text-slate-100 leading-[25.2px] bg-transparent box-border"
+												/>
+												{/* Footer */}
+												<div className="border-t border-slate-100 dark:border-slate-800 flex items-center gap-2 pt-3 pb-4 mt-1">
+													<button
+														type="button"
+														onClick={resetCompose}
+														className="font-medium text-[13px] text-slate-400 dark:text-slate-500 bg-transparent border-none cursor-pointer"
+													>
+														Cancelar
+													</button>
+													{(() => {
+														const len = composeText.length;
+														const tooShort = len < MIN_LEN;
+														const tooLong = len > MAX_LEN;
+														const target = tooShort ? MIN_LEN : MAX_LEN;
+														// Color encodes the state at a glance — amber while
+														// the user can't yet publish, red when over the cap.
+														const color = tooLong
+															? "text-red-500 dark:text-red-400"
+															: tooShort
+																? "text-amber-500 dark:text-amber-400"
+																: "text-slate-400 dark:text-slate-500";
+														return (
+															<span
+																className={`ml-auto mr-3 text-[11px] font-medium ${color}`}
+															>
+																{len}/{target} caracteres
+															</span>
+														);
+													})()}
+													<button
+														type="submit"
+														disabled={
+															composeText.length < MIN_LEN ||
+															composeText.length > MAX_LEN ||
+															composeSubmitting
+														}
+														className="h-9 px-4 rounded-[7px] border-none font-semibold text-[13px] whitespace-nowrap"
+														style={{
+															cursor:
+																composeText.length >= MIN_LEN
+																	? "pointer"
+																	: "default",
+															background:
+																composeText.length >= MIN_LEN &&
+																!composeSubmitting
+																	? "#137ddb"
+																	: "#f1f5f9",
+															color:
+																composeText.length >= MIN_LEN &&
+																!composeSubmitting
+																	? "#fff"
+																	: "#a0aec0",
+														}}
+													>
+														{composeSubmitting
+															? "Publicando…"
+															: "Publicar comentário"}
+													</button>
+												</div>
+											</form>
+										</div>
+									</div>
+								</div>
+							)}
 
-              {loadingComments ? (
-                <div className="flex justify-center py-12">
-                  <div className="w-6 h-6 border-2 border-[#137ddb] border-t-transparent rounded-full animate-spin" />
-                </div>
-              ) : activeComments.length === 0 && !composing ? (
-                <div className="text-center py-12 px-6">
-                  <p className="text-slate-400 dark:text-slate-500 text-sm">Nenhum comentário ainda.</p>
-                  <p className="text-slate-300 dark:text-slate-600 text-xs mt-1">Seja o primeiro a comentar!</p>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (!user) { requireLogin(); return; }
-                      setComposing(true);
-                    }}
-                    className="mt-4 text-[13px] text-[#137ddb] hover:underline"
-                  >
-                    Escrever comentário
-                  </button>
-                </div>
-              ) : (
-                <div className="px-6 py-6 space-y-[12px]">
-                  {activeComments.map((comment) => {
-                    const meta = getTagMetaOrNeutral(comment.tags);
-                    const isOwner = !!user && comment.username === user.username;
+							{loadingComments ? (
+								<div className="flex justify-center py-12">
+									<div className="w-6 h-6 border-2 border-[#137ddb] border-t-transparent rounded-full animate-spin" />
+								</div>
+							) : activeComments.length === 0 && !composing ? (
+								<div className="text-center py-12 px-6">
+									<p className="text-slate-400 dark:text-slate-500 text-sm">
+										Nenhum comentário ainda.
+									</p>
+									<p className="text-slate-300 dark:text-slate-600 text-xs mt-1">
+										Seja o primeiro a comentar!
+									</p>
+									<button
+										type="button"
+										onClick={() => {
+											if (!user) {
+												requireLogin();
+												return;
+											}
+											setComposing(true);
+										}}
+										className="mt-4 text-[13px] text-[#137ddb] hover:underline"
+									>
+										Escrever comentário
+									</button>
+								</div>
+							) : (
+								<div className="px-6 py-6 space-y-[12px]">
+									{activeComments.map((comment) => {
+										const meta = getTagMetaOrNeutral(comment.tags);
+										const isOwner =
+											!!user && comment.username === user.username;
 
-                    if (editingComment?._id === comment._id) {
-                      return (
-                        <div key={comment._id} className="bg-white dark:bg-slate-900 rounded-xl border border-[#e2e8f0] dark:border-slate-700 p-4">
-                          <p className="text-[11px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide mb-2">Editando</p>
-                          <div className="grid grid-cols-2 gap-2 mb-3">
-                            {TAG_ORDER.map((tag) => {
-                              const tm = TAG_META[tag];
-                              const active = editTags[tag];
-                              return (
-                                <button
-                                  key={tag}
-                                  type="button"
-                                  onClick={() => setEditTags((prev) => ({ ...prev, [tag]: !prev[tag] }))}
-                                  className="flex items-center gap-2 px-3 py-2 rounded-lg border text-[13px] font-medium transition"
-                                  style={{ borderColor: active ? tm.border : "#e2e8f0", background: active ? tm.bg : "white", color: active ? tm.color : "#64748b" }}
-                                >
-                                  <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: tm.border }} />
-                                  {tm.label}
-                                </button>
-                              );
-                            })}
-                          </div>
-                          <form onSubmit={handleEditSave}>
-                            <textarea
-                              value={editText}
-                              onChange={(e) => setEditText(e.target.value)}
-                              rows={4}
-                              className="w-full border border-[#e2e8f0] dark:border-slate-700 rounded-lg px-3 py-2 text-[14px] text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-900 resize-none focus:outline-none focus:ring-2 focus:ring-[#137ddb]/30 focus:border-[#137ddb] transition"
-                            />
-                            <div className="flex gap-2 mt-2 justify-end">
-                              <button type="button" onClick={() => setEditingComment(null)} className="text-[13px] text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200">Cancelar</button>
-                              <button type="submit" className="bg-[#137ddb] text-white text-[13px] font-semibold px-3 py-1.5 rounded-lg hover:bg-[#0f69c0] transition">Salvar</button>
-                            </div>
-                          </form>
-                        </div>
-                      );
-                    }
+										if (editingComment?._id === comment._id) {
+											return (
+												<div
+													key={comment._id}
+													className="bg-white dark:bg-slate-900 rounded-xl border border-[#e2e8f0] dark:border-slate-700 p-4"
+												>
+													<p className="text-[11px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide mb-2">
+														Editando
+													</p>
+													<div className="grid grid-cols-2 gap-2 mb-3">
+														{TAG_ORDER.map((tag) => {
+															const tm = TAG_META[tag];
+															const active = editTags[tag];
+															return (
+																<button
+																	key={tag}
+																	type="button"
+																	onClick={() =>
+																		setEditTags((prev) => ({
+																			...prev,
+																			[tag]: !prev[tag],
+																		}))
+																	}
+																	className="flex items-center gap-2 px-3 py-2 rounded-lg border text-[13px] font-medium transition"
+																	style={{
+																		borderColor: active ? tm.border : "#e2e8f0",
+																		background: active ? tm.bg : "white",
+																		color: active ? tm.color : "#64748b",
+																	}}
+																>
+																	<span
+																		className="w-2 h-2 rounded-full flex-shrink-0"
+																		style={{ background: tm.border }}
+																	/>
+																	{tm.label}
+																</button>
+															);
+														})}
+													</div>
+													<form onSubmit={handleEditSave}>
+														<textarea
+															value={editText}
+															onChange={(e) => setEditText(e.target.value)}
+															rows={4}
+															className="w-full border border-[#e2e8f0] dark:border-slate-700 rounded-lg px-3 py-2 text-[14px] text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-900 resize-none focus:outline-none focus:ring-2 focus:ring-[#137ddb]/30 focus:border-[#137ddb] transition"
+														/>
+														<div className="flex gap-2 mt-2 justify-end">
+															<button
+																type="button"
+																onClick={() => setEditingComment(null)}
+																className="text-[13px] text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+															>
+																Cancelar
+															</button>
+															<button
+																type="submit"
+																className="bg-[#137ddb] text-white text-[13px] font-semibold px-3 py-1.5 rounded-lg hover:bg-[#0f69c0] transition"
+															>
+																Salvar
+															</button>
+														</div>
+													</form>
+												</div>
+											);
+										}
 
-                    const borderColor = meta.border;
-                    return (
-                      <div
-                        key={comment._id}
-                        className="bg-white dark:bg-slate-900 border-l-4 border border-solid rounded-r-lg overflow-hidden shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06)]"
-                        style={{ borderColor }}
-                      >
-                        {/* Header row: type icon + label + username + date */}
-                        <div className="flex items-center pt-4 px-[18px] h-9">
-                          {/* All categories as colored pills, ordered most
+										const borderColor = meta.border;
+										return (
+											<div
+												key={comment._id}
+												className="bg-white dark:bg-slate-900 border-l-4 border border-solid rounded-r-lg overflow-hidden shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06)]"
+												style={{ borderColor }}
+											>
+												{/* Header row: type icon + label + username + date */}
+												<div className="flex items-center pt-4 px-[18px] h-9">
+													{/* All categories as colored pills, ordered most
                               personal → most studied; empty → "Comentário". */}
-                          <TagBadges tags={comment.tags} size="md" />
-                          {/* Username — linkar para o perfil público */}
-                          <span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 ml-auto whitespace-nowrap inline-flex items-center gap-1">
-                            <Link
-                              href={`/u/${comment.username}`}
-                              className="hover:underline"
-                            >
-                              {comment.username}
-                            </Link>
-                            {comment.verified && (
-                              <span
-                                className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
-                                title={comment.verifiedBy ? `Verificado por @${comment.verifiedBy}` : "Verificado por moderador"}
-                                aria-label={comment.verifiedBy ? `Verificado por @${comment.verifiedBy}` : "Verificado por moderador"}
-                              >
-                                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                  <polyline points="20 6 9 17 4 12" />
-                                </svg>
-                              </span>
-                            )}
-                          </span>
-                          {/* Date */}
-                          <span className="font-normal text-xs text-slate-400 dark:text-slate-500 ml-3 whitespace-nowrap">
-                            {dateFormat(comment.createdAt)}
-                          </span>
-                        </div>
+													<TagBadges tags={comment.tags} size="md" />
+													{/* Username — linkar para o perfil público */}
+													<span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 ml-auto whitespace-nowrap inline-flex items-center gap-1">
+														<Link
+															href={`/u/${comment.username}`}
+															className="hover:underline"
+														>
+															{comment.username}
+														</Link>
+														{comment.verified && (
+															<span
+																className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
+																title={
+																	comment.verifiedBy
+																		? `Verificado por @${comment.verifiedBy}`
+																		: "Verificado por moderador"
+																}
+																aria-label={
+																	comment.verifiedBy
+																		? `Verificado por @${comment.verifiedBy}`
+																		: "Verificado por moderador"
+																}
+															>
+																<svg
+																	width="10"
+																	height="10"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	strokeWidth="3"
+																	strokeLinecap="round"
+																	strokeLinejoin="round"
+																	aria-hidden="true"
+																>
+																	<polyline points="20 6 9 17 4 12" />
+																</svg>
+															</span>
+														)}
+													</span>
+													{/* Date */}
+													<span className="font-normal text-xs text-slate-400 dark:text-slate-500 ml-3 whitespace-nowrap">
+														{dateFormat(comment.createdAt)}
+													</span>
+												</div>
 
-                        {/* Community badge — only when the comment was posted into a community */}
-                        {comment.communitySlug && (
-                          <div className="pt-2 px-[18px]">
-                            <Link
-                              href={`/communities/${comment.communitySlug}`}
-                              data-testid={`comment-community-badge-${comment.communitySlug}`}
-                              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand-tint/30 dark:bg-brand-tint/20 text-brand text-[11px] font-semibold no-underline hover:bg-brand-tint/60 dark:hover:bg-brand-tint/40 transition"
-                            >
-                              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-                                <circle cx="9" cy="7" r="4" />
-                              </svg>
-                              /{comment.communitySlug}
-                            </Link>
-                          </div>
-                        )}
+												{/* Community badge — only when the comment was posted into a community */}
+												{comment.communitySlug && (
+													<div className="pt-2 px-[18px]">
+														<Link
+															href={`/communities/${comment.communitySlug}`}
+															data-testid={`comment-community-badge-${comment.communitySlug}`}
+															className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand-tint/30 dark:bg-brand-tint/20 text-brand text-[11px] font-semibold no-underline hover:bg-brand-tint/60 dark:hover:bg-brand-tint/40 transition"
+														>
+															<svg
+																width="10"
+																height="10"
+																viewBox="0 0 24 24"
+																fill="none"
+																stroke="currentColor"
+																strokeWidth="2.5"
+																strokeLinecap="round"
+																strokeLinejoin="round"
+																aria-hidden="true"
+															>
+																<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+																<circle cx="9" cy="7" r="4" />
+															</svg>
+															/{comment.communitySlug}
+														</Link>
+													</div>
+												)}
 
-                        {/* Paragraph */}
-                        <div className="pt-2.5 px-[18px]">
-                          <p className="font-normal text-[14px] text-gray-700 dark:text-gray-300 leading-[25.2px] m-0 whitespace-pre-wrap">
-                            {comment.text}
-                          </p>
-                        </div>
+												{/* Paragraph */}
+												<div className="pt-2.5 px-[18px]">
+													<p className="font-normal text-[14px] text-gray-700 dark:text-gray-300 leading-[25.2px] m-0 whitespace-pre-wrap">
+														{comment.text}
+													</p>
+												</div>
 
-                        {/* Footer actions */}
-                        <div className="border-t border-[#f7fafc] dark:border-slate-800 mt-3 mx-[18px] flex items-center h-[50.667px]">
-                          {/* Útil button */}
-                          <button
-                            type="button"
-                            onClick={() => handleLike(comment._id)}
-                            className="flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap"
-                          >
-                            <svg width="13" height="13" viewBox="0 0 24 24" fill={comment.likedByMe ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-                            </svg>
-                            Útil · {comment.likeCount}
-                          </button>
+												{/* Footer actions */}
+												<div className="border-t border-[#f7fafc] dark:border-slate-800 mt-3 mx-[18px] flex items-center h-[50.667px]">
+													{/* Útil button */}
+													<button
+														type="button"
+														onClick={() => handleLike(comment._id)}
+														className="flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap"
+													>
+														<svg
+															width="13"
+															height="13"
+															viewBox="0 0 24 24"
+															fill={comment.likedByMe ? "currentColor" : "none"}
+															stroke="currentColor"
+															strokeWidth="2"
+															strokeLinecap="round"
+															strokeLinejoin="round"
+														>
+															<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+														</svg>
+														Útil · {comment.likeCount}
+													</button>
 
-                          {/* Contribuir button */}
-                          <button
-                            type="button"
-                            onClick={() => handleDiscussion(comment._id, comment.text, `${comment.username} ${comment.bookReference}`)}
-                            className="flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap ml-0.5"
-                          >
-                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                            </svg>
-                            Contribuir
-                          </button>
+													{/* Contribuir button */}
+													<button
+														type="button"
+														onClick={() =>
+															handleDiscussion(
+																comment._id,
+																comment.text,
+																`${comment.username} ${comment.bookReference}`,
+															)
+														}
+														className="flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap ml-0.5"
+													>
+														<svg
+															width="13"
+															height="13"
+															viewBox="0 0 24 24"
+															fill="none"
+															stroke="currentColor"
+															strokeWidth="2"
+															strokeLinecap="round"
+															strokeLinejoin="round"
+														>
+															<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+														</svg>
+														Contribuir
+													</button>
 
-                          {/* Share as image card (Pinterest-like) */}
-                          <ShareCommentButton
-                            commentId={comment._id}
-                            text={comment.text}
-                            username={comment.username}
-                            reference={comment.bookReference}
-                          />
+													{/* Share as image card (Pinterest-like) */}
+													<ShareCommentButton
+														commentId={comment._id}
+														text={comment.text}
+														username={comment.username}
+														reference={comment.bookReference}
+													/>
 
-                          {/* N Perspectiva badge */}
-                          <div className="ml-auto bg-brand-tint rounded-[12px] h-[22.5px] flex items-center px-2.5 whitespace-nowrap">
-                            <span className="font-semibold text-[11px] text-brand">
-                              {comment.likeCount > 0 ? `${comment.likeCount} Perspectiva${comment.likeCount !== 1 ? "s" : ""}` : "0 Perspectivas"}
-                            </span>
-                          </div>
+													{/* N Perspectiva badge */}
+													<div className="ml-auto bg-brand-tint rounded-[12px] h-[22.5px] flex items-center px-2.5 whitespace-nowrap">
+														<span className="font-semibold text-[11px] text-brand">
+															{comment.likeCount > 0
+																? `${comment.likeCount} Perspectiva${comment.likeCount !== 1 ? "s" : ""}`
+																: "0 Perspectivas"}
+														</span>
+													</div>
 
-                          {/* Moderator-only: toggle the admin-verified badge inline. */}
-                          {user?.moderator && (
-                            <button
-                              type="button"
-                              onClick={() => handleToggleVerified(comment._id)}
-                              data-testid={`mod-verify-${comment._id}`}
-                              data-verified={comment.verified ? "true" : "false"}
-                              aria-label={comment.verified ? "Remover verificação" : "Verificar comentário"}
-                              title={comment.verified ? "Remover verificação" : "Verificar comentário"}
-                              className={`flex items-center justify-center w-7 h-7 ml-1 rounded-[5px] border-none bg-transparent cursor-pointer transition-colors ${
-                                comment.verified
-                                  ? "text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300"
-                                  : "text-slate-400 dark:text-slate-500 hover:text-emerald-600 dark:hover:text-emerald-400"
-                              }`}
-                            >
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-                                <polyline points="22 4 12 14.01 9 11.01" />
-                              </svg>
-                            </button>
-                          )}
+													{/* Moderator-only: toggle the admin-verified badge inline. */}
+													{user?.moderator && (
+														<button
+															type="button"
+															onClick={() => handleToggleVerified(comment._id)}
+															data-testid={`mod-verify-${comment._id}`}
+															data-verified={
+																comment.verified ? "true" : "false"
+															}
+															aria-label={
+																comment.verified
+																	? "Remover verificação"
+																	: "Verificar comentário"
+															}
+															title={
+																comment.verified
+																	? "Remover verificação"
+																	: "Verificar comentário"
+															}
+															className={`flex items-center justify-center w-7 h-7 ml-1 rounded-[5px] border-none bg-transparent cursor-pointer transition-colors ${
+																comment.verified
+																	? "text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300"
+																	: "text-slate-400 dark:text-slate-500 hover:text-emerald-600 dark:hover:text-emerald-400"
+															}`}
+														>
+															<svg
+																width="14"
+																height="14"
+																viewBox="0 0 24 24"
+																fill="none"
+																stroke="currentColor"
+																strokeWidth="2"
+																strokeLinecap="round"
+																strokeLinejoin="round"
+																aria-hidden="true"
+															>
+																<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+																<polyline points="22 4 12 14.01 9 11.01" />
+															</svg>
+														</button>
+													)}
 
-                          {/* Owner: edit pencil. Non-owner: report flag. */}
-                          <div className="relative ml-1">
-                            {isOwner ? (
-                              <button
-                                type="button"
-                                aria-label="Editar comentário"
-                                title="Editar"
-                                className="flex items-center justify-center w-7 h-7 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-                                onClick={() => startEdit(comment)}
-                              >
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                                </svg>
-                              </button>
-                            ) : (
-                              <button
-                                type="button"
-                                aria-label="Reportar comentário"
-                                title="Reportar"
-                                data-testid={`report-${comment._id}`}
-                                className="flex items-center justify-center w-7 h-7 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
-                                onClick={() => handleReport(comment._id)}
-                              >
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                  <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
-                                  <line x1="4" y1="22" x2="4" y2="15" />
-                                </svg>
-                              </button>
-                            )}
-                          </div>
+													{/* Owner: edit pencil. Non-owner: report flag. */}
+													<div className="relative ml-1">
+														{isOwner ? (
+															<button
+																type="button"
+																aria-label="Editar comentário"
+																title="Editar"
+																className="flex items-center justify-center w-7 h-7 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+																onClick={() => startEdit(comment)}
+															>
+																<svg
+																	width="14"
+																	height="14"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	strokeWidth="2"
+																	strokeLinecap="round"
+																	strokeLinejoin="round"
+																>
+																	<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+																	<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+																</svg>
+															</button>
+														) : (
+															<button
+																type="button"
+																aria-label="Reportar comentário"
+																title="Reportar"
+																data-testid={`report-${comment._id}`}
+																className="flex items-center justify-center w-7 h-7 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+																onClick={() => handleReport(comment._id)}
+															>
+																<svg
+																	width="14"
+																	height="14"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	strokeWidth="2"
+																	strokeLinecap="round"
+																	strokeLinejoin="round"
+																>
+																	<path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+																	<line x1="4" y1="22" x2="4" y2="15" />
+																</svg>
+															</button>
+														)}
+													</div>
 
-                          {/* Owner: delete inline so they don't have to hunt
+													{/* Owner: delete inline so they don't have to hunt
                               for the comment on their profile. Backend still
                               authorizes owner|moderator; we surface it only to
                               the author here per product decision. */}
-                          {isOwner && (
-                            <button
-                              type="button"
-                              aria-label="Excluir comentário"
-                              title="Excluir"
-                              data-testid={`delete-${comment._id}`}
-                              className="flex items-center justify-center w-7 h-7 ml-1 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-red-600 dark:hover:text-red-400 transition-colors"
-                              onClick={() => handleDelete(comment._id)}
-                            >
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                <polyline points="3 6 5 6 21 6" />
-                                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                              </svg>
-                            </button>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </aside>
-        )}
-      </div>
+													{isOwner && (
+														<button
+															type="button"
+															aria-label="Excluir comentário"
+															title="Excluir"
+															data-testid={`delete-${comment._id}`}
+															className="flex items-center justify-center w-7 h-7 ml-1 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+															onClick={() => handleDelete(comment._id)}
+														>
+															<svg
+																width="14"
+																height="14"
+																viewBox="0 0 24 24"
+																fill="none"
+																stroke="currentColor"
+																strokeWidth="2"
+																strokeLinecap="round"
+																strokeLinejoin="round"
+																aria-hidden="true"
+															>
+																<polyline points="3 6 5 6 21 6" />
+																<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+															</svg>
+														</button>
+													)}
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							)}
+						</div>
+					</aside>
+				)}
+			</div>
 
-      {showTutorial && (
-        <Tutorial
-          steps={CHAPTER_TUTORIAL}
-          onFinished={() => {
-            tutorial.markCompleted();
-            // Strip ?tour=1 so a refresh after dismiss doesn't reopen it.
-            if (forceTour && typeof window !== "undefined") {
-              const url = new URL(window.location.href);
-              url.searchParams.delete("tour");
-              window.history.replaceState(null, "", url.toString());
-            }
-          }}
-        />
-      )}
-    </div>
-  );
+			{showTutorial && (
+				<Tutorial
+					steps={CHAPTER_TUTORIAL}
+					onFinished={() => {
+						tutorial.markCompleted();
+						// Strip ?tour=1 so a refresh after dismiss doesn't reopen it.
+						if (forceTour && typeof window !== "undefined") {
+							const url = new URL(window.location.href);
+							url.searchParams.delete("tour");
+							window.history.replaceState(null, "", url.toString());
+						}
+					}}
+				/>
+			)}
+		</div>
+	);
 }

--- a/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
+++ b/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
@@ -646,8 +646,7 @@ export default function ChapterClient({
 			if (
 				!poppedByBack &&
 				window.location.pathname === openedAtPath &&
-				(window.history.state as { bcPanel?: boolean } | null)?.bcPanel ===
-					true
+				(window.history.state as { bcPanel?: boolean } | null)?.bcPanel === true
 			) {
 				window.history.back();
 			}

--- a/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
+++ b/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
@@ -1345,13 +1345,22 @@ export default function ChapterClient({
 												className="bg-white dark:bg-slate-900 border-l-4 border border-solid rounded-r-lg overflow-hidden shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06)]"
 												style={{ borderColor }}
 											>
-												{/* Header row: type icon + label + username + date */}
-												<div className="flex items-center pt-4 px-[18px] h-9">
+												{/* Header row: category pills + username + date.
+                            No fixed height — with 2+ categories the pills
+                            wrap to a second line; a locked h-9 used to clip
+                            them into the paragraph below ("rente ao texto").
+                            items-start keeps the username aligned to the
+                            first pill row. */}
+												<div className="flex items-start gap-2 pt-4 pb-1.5 px-[18px]">
 													{/* All categories as colored pills, ordered most
                               personal → most studied; empty → "Comentário". */}
-													<TagBadges tags={comment.tags} size="md" />
+													<TagBadges
+														tags={comment.tags}
+														size="md"
+														className="min-w-0"
+													/>
 													{/* Username — linkar para o perfil público */}
-													<span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 ml-auto whitespace-nowrap inline-flex items-center gap-1">
+													<span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 ml-auto shrink-0 pt-0.5 whitespace-nowrap inline-flex items-center gap-1">
 														<Link
 															href={`/u/${comment.username}`}
 															className="hover:underline"
@@ -1486,14 +1495,12 @@ export default function ChapterClient({
 														reference={comment.bookReference}
 													/>
 
-													{/* N Perspectiva badge */}
-													<div className="ml-auto bg-brand-tint rounded-[12px] h-[22.5px] flex items-center px-2.5 whitespace-nowrap">
-														<span className="font-semibold text-[11px] text-brand">
-															{comment.likeCount > 0
-																? `${comment.likeCount} Perspectiva${comment.likeCount !== 1 ? "s" : ""}`
-																: "0 Perspectivas"}
-														</span>
-													</div>
+													{/* The "N Perspectivas" badge was removed: it merely
+                              re-displayed comment.likeCount, which the
+                              "Útil · N" button already shows — pure
+                              duplication. Spacer keeps the moderation /
+                              owner icon controls right-aligned. */}
+													<div className="ml-auto" />
 
 													{/* Moderator-only: toggle the admin-verified badge inline. */}
 													{user?.moderator && (

--- a/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
+++ b/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
@@ -1156,6 +1156,26 @@ export default function ChapterClient({
                               </button>
                             )}
                           </div>
+
+                          {/* Owner: delete inline so they don't have to hunt
+                              for the comment on their profile. Backend still
+                              authorizes owner|moderator; we surface it only to
+                              the author here per product decision. */}
+                          {isOwner && (
+                            <button
+                              type="button"
+                              aria-label="Excluir comentário"
+                              title="Excluir"
+                              data-testid={`delete-${comment._id}`}
+                              className="flex items-center justify-center w-7 h-7 ml-1 rounded-[5px] border-none bg-transparent cursor-pointer text-slate-400 dark:text-slate-500 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                              onClick={() => handleDelete(comment._id)}
+                            >
+                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                <polyline points="3 6 5 6 21 6" />
+                                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                              </svg>
+                            </button>
+                          )}
                         </div>
                       </div>
                     );

--- a/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
+++ b/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
@@ -19,6 +19,8 @@ import { CHAPTER_TUTORIAL, CHAPTER_TUTORIAL_NAME } from "@/lib/tutorial-config";
 import { MarkAsReadButton } from "@/components/MarkAsReadButton";
 import { TAG_META, TAG_ORDER, getTagMetaOrNeutral } from "@/lib/tag-meta";
 import { TagIcon } from "@/components/TagIcon";
+import { TagBadges } from "@/components/TagBadges";
+import { ShareCommentButton } from "@/components/ShareCommentButton";
 import {
   toggleLikeAction,
   reportCommentAction,
@@ -1012,14 +1014,9 @@ export default function ChapterClient({
                       >
                         {/* Header row: type icon + label + username + date */}
                         <div className="flex items-center pt-4 px-[18px] h-9">
-                          {/* Type-specific icon — color matches the tag */}
-                          <span aria-hidden="true" className="flex-shrink-0" style={{ color: meta.color }}>
-                            <TagIcon name={meta.icon} width={18} height={18} />
-                          </span>
-                          {/* Type label */}
-                          <span className="font-semibold text-xs ml-2 whitespace-nowrap" style={{ color: meta.color }}>
-                            {meta.label}
-                          </span>
+                          {/* All categories as colored pills, ordered most
+                              personal → most studied; empty → "Comentário". */}
+                          <TagBadges tags={comment.tags} size="md" />
                           {/* Username — linkar para o perfil público */}
                           <span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 ml-auto whitespace-nowrap inline-flex items-center gap-1">
                             <Link
@@ -1095,6 +1092,14 @@ export default function ChapterClient({
                             </svg>
                             Contribuir
                           </button>
+
+                          {/* Share as image card (Pinterest-like) */}
+                          <ShareCommentButton
+                            commentId={comment._id}
+                            text={comment.text}
+                            username={comment.username}
+                            reference={comment.bookReference}
+                          />
 
                           {/* N Perspectiva badge */}
                           <div className="ml-auto bg-brand-tint rounded-[12px] h-[22.5px] flex items-center px-2.5 whitespace-nowrap">

--- a/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
+++ b/nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsx
@@ -622,6 +622,38 @@ export default function ChapterClient({
 		return () => document.body.classList.remove("bc-hide-tabbar");
 	}, [showSidebar]);
 
+	// Android / browser back must CLOSE the open comment panel, not navigate
+	// away. In a standalone PWA the system back maps to history.back(); with
+	// no synthetic history entry it pops the page — and EXITS the app when
+	// the chapter is the first entry (PWA launched from icon / share deep
+	// link). Push one entry while the panel is open; a popstate (back) then
+	// just closes it. On a non-back close (X / Esc / re-tapping the same
+	// verse) we pop our own entry to keep the history stack balanced —
+	// skipped if we navigated away (pathname changed, e.g. tapping an
+	// in-panel @username link) so we don't hijack that navigation.
+	useEffect(() => {
+		if (!showSidebar || typeof window === "undefined") return;
+		const openedAtPath = window.location.pathname;
+		let poppedByBack = false;
+		window.history.pushState({ bcPanel: true }, "");
+		const onPop = () => {
+			poppedByBack = true;
+			handleClose();
+		};
+		window.addEventListener("popstate", onPop);
+		return () => {
+			window.removeEventListener("popstate", onPop);
+			if (
+				!poppedByBack &&
+				window.location.pathname === openedAtPath &&
+				(window.history.state as { bcPanel?: boolean } | null)?.bcPanel ===
+					true
+			) {
+				window.history.back();
+			}
+		};
+	}, [showSidebar, handleClose]);
+
 	// Swipe-to-navigate (touch only, mobile). Threshold ~60px horizontal,
 	// ignored if vertical movement dominates (avoids hijacking scrolls)
 	// or if the sidebar is open (would conflict with closing the drawer).

--- a/nextjs/src/app/profile/ProfileClient.tsx
+++ b/nextjs/src/app/profile/ProfileClient.tsx
@@ -42,7 +42,8 @@ interface UserProfile {
   followingCount?: number;
 }
 
-import { getTagMetaOrNeutral } from "@/lib/tag-meta";
+import { getTagMetaOrNeutral, getTagMetas } from "@/lib/tag-meta";
+import { TagBadges } from "@/components/TagBadges";
 import { parseBookRef } from "@/lib/parse-book-ref";
 import { TagIcon } from "@/components/TagIcon";
 import { AppHeader } from "@/components/AppHeader";
@@ -132,17 +133,7 @@ function ProfileCommentCard({
     >
       {/* Header */}
       <div className="flex items-center gap-2 mb-2.5">
-        <span
-          className="inline-flex items-center gap-1 rounded-[10px] pl-1.5 pr-2 h-[20.5px] shrink-0"
-          style={{ background: type.bg, color: type.color }}
-        >
-          <span aria-hidden="true" className="flex">
-            <TagIcon name={type.icon} width={12} height={12} />
-          </span>
-          <span className="font-semibold text-[11px] leading-[16.5px] whitespace-nowrap">
-            {type.label}
-          </span>
-        </span>
+        <TagBadges tags={comment.tags} className="shrink-0" />
         {comment.bookReference && (
           <span className="inline-flex items-center bg-brand-wash rounded px-[7px] h-5 shrink-0">
             <span className="font-bold text-xs text-brand leading-[18px] whitespace-nowrap">
@@ -223,17 +214,7 @@ function FavoriteCard({ comment }: { comment: CommentData }) {
           {comment.username}
         </span>
         {/* Type badge */}
-        <span
-          className="inline-flex items-center gap-1 rounded-[10px] pl-1.5 pr-2 h-[20.5px] shrink-0"
-          style={{ background: type.bg, color: type.color }}
-        >
-          <span aria-hidden="true" className="flex">
-            <TagIcon name={type.icon} width={12} height={12} />
-          </span>
-          <span className="font-semibold text-[11px] leading-[16.5px] whitespace-nowrap">
-            {type.label}
-          </span>
-        </span>
+        <TagBadges tags={comment.tags} className="shrink-0" />
         {/* Verse */}
         {comment.bookReference && (
           <span className="font-bold text-[11px] text-brand whitespace-nowrap shrink-0">
@@ -832,7 +813,11 @@ export default function ProfileClient({ user }: { user: SessionUser }) {
   const filteredFavorites = useMemo(() => {
     let list = favorites;
     if (favTypeFilter !== "Todos") {
-      list = list.filter(c => getCommentType(c.tags).label === favTypeFilter);
+      // Match if ANY of the comment's categories equals the filter (a
+      // multi-tag comment shows up under each of its categories).
+      list = list.filter(c =>
+        getTagMetas(c.tags).some(m => m.label === favTypeFilter),
+      );
     }
     if (favSearch) {
       const q = favSearch.toLowerCase();

--- a/nextjs/src/app/profile/ProfileClient.tsx
+++ b/nextjs/src/app/profile/ProfileClient.tsx
@@ -45,7 +45,6 @@ interface UserProfile {
 import { getTagMetaOrNeutral, getTagMetas } from "@/lib/tag-meta";
 import { TagBadges } from "@/components/TagBadges";
 import { parseBookRef } from "@/lib/parse-book-ref";
-import { TagIcon } from "@/components/TagIcon";
 import { AppHeader } from "@/components/AppHeader";
 
 type Tab = "overview" | "comments" | "favorites" | "badges" | "config";

--- a/nextjs/src/app/profile/ProfileClient.tsx
+++ b/nextjs/src/app/profile/ProfileClient.tsx
@@ -18,28 +18,31 @@ import { useTutorial } from "@/lib/use-tutorial";
 import { CHAPTER_TUTORIAL_NAME } from "@/lib/tutorial-config";
 import { BadgesTab } from "./_components/BadgesTab";
 
-const { beliefs, states } = collectionsData as { beliefs: string[]; states: string[] };
+const { beliefs, states } = collectionsData as {
+	beliefs: string[];
+	states: string[];
+};
 
 interface SessionUser {
-  name: string;
-  email: string;
-  username: string;
-  moderator: boolean;
+	name: string;
+	email: string;
+	username: string;
+	moderator: boolean;
 }
 
 interface UserProfile {
-  email: string;
-  username: string;
-  displayName?: string;
-  belief?: string;
-  showBelief?: boolean;
-  stateName?: string;
-  createdAt?: string;
-  booksCount: number;
-  chaptersCount: number;
-  commentsCount: number;
-  followersCount?: number;
-  followingCount?: number;
+	email: string;
+	username: string;
+	displayName?: string;
+	belief?: string;
+	showBelief?: boolean;
+	stateName?: string;
+	createdAt?: string;
+	booksCount: number;
+	chaptersCount: number;
+	commentsCount: number;
+	followersCount?: number;
+	followingCount?: number;
 }
 
 import { getTagMetaOrNeutral, getTagMetas } from "@/lib/tag-meta";
@@ -51,1191 +54,1428 @@ import { AppHeader } from "@/components/AppHeader";
 type Tab = "overview" | "comments" | "favorites" | "badges" | "config";
 type TypeFilter = "Todos" | "Exegese" | "Devocional" | "Pessoal" | "Inspirado";
 
-const TYPE_FILTERS: TypeFilter[] = ["Todos", "Exegese", "Devocional", "Pessoal", "Inspirado"];
+const TYPE_FILTERS: TypeFilter[] = [
+	"Todos",
+	"Exegese",
+	"Devocional",
+	"Pessoal",
+	"Inspirado",
+];
 
 function getInitials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+	const parts = name.trim().split(/\s+/);
+	if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+	return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
 function formatMemberSince(dateStr?: string): string {
-  if (!dateStr) return "";
-  const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return "";
-  return d.toLocaleDateString("pt-BR", { month: "long", year: "numeric" });
+	if (!dateStr) return "";
+	const d = new Date(dateStr);
+	if (isNaN(d.getTime())) return "";
+	return d.toLocaleDateString("pt-BR", { month: "long", year: "numeric" });
 }
 
 function getCommentType(tags: string[]) {
-  return getTagMetaOrNeutral(tags);
+	return getTagMetaOrNeutral(tags);
 }
 
 /* ─────────────────── Shared search bar ─────────────────── */
 function SearchBar({
-  value,
-  onChange,
-  placeholder,
+	value,
+	onChange,
+	placeholder,
 }: {
-  value: string;
-  onChange: (v: string) => void;
-  placeholder: string;
+	value: string;
+	onChange: (v: string) => void;
+	placeholder: string;
 }) {
-  return (
-    <div className="relative w-full flex-shrink-0">
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg h-[40.833px] flex items-center pl-9 pr-3 overflow-hidden">
-        <input
-          type="text"
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="flex-1 text-[13px] text-slate-800 dark:text-slate-100 bg-transparent border-none outline-none"
-        />
-        {value && (
-          <button
-            type="button"
-            onClick={() => onChange("")}
-            className="text-slate-400 dark:text-slate-500 bg-transparent border-none cursor-pointer flex items-center"
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
-        )}
-      </div>
-      <svg
-        width="14" height="14" viewBox="0 0 24 24" fill="none"
-        stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-        className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
-      >
-        <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
-      </svg>
-    </div>
-  );
+	return (
+		<div className="relative w-full flex-shrink-0">
+			<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg h-[40.833px] flex items-center pl-9 pr-3 overflow-hidden">
+				<input
+					type="text"
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+					placeholder={placeholder}
+					className="flex-1 text-[13px] text-slate-800 dark:text-slate-100 bg-transparent border-none outline-none"
+				/>
+				{value && (
+					<button
+						type="button"
+						onClick={() => onChange("")}
+						className="text-slate-400 dark:text-slate-500 bg-transparent border-none cursor-pointer flex items-center"
+					>
+						<svg
+							width="12"
+							height="12"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2.5"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<line x1="18" y1="6" x2="6" y2="18" />
+							<line x1="6" y1="6" x2="18" y2="18" />
+						</svg>
+					</button>
+				)}
+			</div>
+			<svg
+				width="14"
+				height="14"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="#94a3b8"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
+			>
+				<circle cx="11" cy="11" r="8" />
+				<path d="m21 21-4.35-4.35" />
+			</svg>
+		</div>
+	);
 }
 
 /* ─────────────────── My-comment card (no author) ─────────────────── */
 function ProfileCommentCard({
-  comment,
-  onEdit,
-  onDelete,
+	comment,
+	onEdit,
+	onDelete,
 }: {
-  comment: CommentData;
-  onEdit?: (c: CommentData) => void;
-  onDelete?: (id: string) => void;
+	comment: CommentData;
+	onEdit?: (c: CommentData) => void;
+	onDelete?: (id: string) => void;
 }) {
-  const type = getCommentType(comment.tags);
-  const nav  = parseBookRef(comment.bookReference ?? "");
+	const type = getCommentType(comment.tags);
+	const nav = parseBookRef(comment.bookReference ?? "");
 
-  return (
-    <div
-      className="bg-white dark:bg-slate-900 border-l-4 border-y border-r border-slate-200 dark:border-slate-700 rounded-r-[10px] shadow-sm py-3.5 px-[18px]"
-      style={{ borderLeftColor: type.color }}
-    >
-      {/* Header */}
-      <div className="flex items-center gap-2 mb-2.5">
-        <TagBadges tags={comment.tags} className="shrink-0" />
-        {comment.bookReference && (
-          <span className="inline-flex items-center bg-brand-wash rounded px-[7px] h-5 shrink-0">
-            <span className="font-bold text-xs text-brand leading-[18px] whitespace-nowrap">
-              {comment.bookReference}
-            </span>
-          </span>
-        )}
-        <span className="ml-auto text-[11px] text-slate-400 dark:text-slate-500 whitespace-nowrap">
-          {dateFormat(comment.createdAt)}
-        </span>
-        {(onEdit || onDelete) && (
-          <div className="flex gap-1.5 ml-2">
-            {onEdit && (
-              <button
-                type="button"
-                onClick={() => onEdit(comment)}
-                className="text-[11px] text-slate-400 dark:text-slate-500 bg-transparent border-none cursor-pointer px-1 py-0.5 rounded hover:text-slate-600 dark:hover:text-slate-300 transition"
-              >
-                Editar
-              </button>
-            )}
-            {onDelete && (
-              <button
-                type="button"
-                onClick={() => onDelete(comment._id)}
-                className="text-[11px] text-red-400 dark:text-red-500 bg-transparent border-none cursor-pointer px-1 py-0.5 rounded hover:text-red-600 dark:hover:text-red-400 transition"
-              >
-                Excluir
-              </button>
-            )}
-          </div>
-        )}
-      </div>
+	return (
+		<div
+			className="bg-white dark:bg-slate-900 border-l-4 border-y border-r border-slate-200 dark:border-slate-700 rounded-r-[10px] shadow-sm py-3.5 px-[18px]"
+			style={{ borderLeftColor: type.color }}
+		>
+			{/* Header */}
+			<div className="flex items-center gap-2 mb-2.5">
+				<TagBadges tags={comment.tags} className="shrink-0" />
+				{comment.bookReference && (
+					<span className="inline-flex items-center bg-brand-wash rounded px-[7px] h-5 shrink-0">
+						<span className="font-bold text-xs text-brand leading-[18px] whitespace-nowrap">
+							{comment.bookReference}
+						</span>
+					</span>
+				)}
+				<span className="ml-auto text-[11px] text-slate-400 dark:text-slate-500 whitespace-nowrap">
+					{dateFormat(comment.createdAt)}
+				</span>
+				{(onEdit || onDelete) && (
+					<div className="flex gap-1.5 ml-2">
+						{onEdit && (
+							<button
+								type="button"
+								onClick={() => onEdit(comment)}
+								className="text-[11px] text-slate-400 dark:text-slate-500 bg-transparent border-none cursor-pointer px-1 py-0.5 rounded hover:text-slate-600 dark:hover:text-slate-300 transition"
+							>
+								Editar
+							</button>
+						)}
+						{onDelete && (
+							<button
+								type="button"
+								onClick={() => onDelete(comment._id)}
+								className="text-[11px] text-red-400 dark:text-red-500 bg-transparent border-none cursor-pointer px-1 py-0.5 rounded hover:text-red-600 dark:hover:text-red-400 transition"
+							>
+								Excluir
+							</button>
+						)}
+					</div>
+				)}
+			</div>
 
-      {/* Text */}
-      <p className="text-[13px] text-gray-700 dark:text-gray-300 leading-[22.75px] m-0 mb-2.5 line-clamp-2">
-        {comment.text}
-      </p>
+			{/* Text */}
+			<p className="text-[13px] text-gray-700 dark:text-gray-300 leading-[22.75px] m-0 mb-2.5 line-clamp-2">
+				{comment.text}
+			</p>
 
-      {/* Context link */}
-      {nav && (
-        <Link
-          href={`/verses/${nav.abbrev}/${nav.chapter}#${nav.verse}`}
-          className="inline-flex items-center gap-1.5 font-semibold text-[11px] text-brand no-underline hover:underline"
-        >
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-            <polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" />
-          </svg>
-          Ver no contexto ({comment.bookReference})
-        </Link>
-      )}
-    </div>
-  );
+			{/* Context link */}
+			{nav && (
+				<Link
+					href={`/verses/${nav.abbrev}/${nav.chapter}#${nav.verse}`}
+					className="inline-flex items-center gap-1.5 font-semibold text-[11px] text-brand no-underline hover:underline"
+				>
+					<svg
+						width="11"
+						height="11"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+						<polyline points="15 3 21 3 21 9" />
+						<line x1="10" y1="14" x2="21" y2="3" />
+					</svg>
+					Ver no contexto ({comment.bookReference})
+				</Link>
+			)}
+		</div>
+	);
 }
 
 /* ─────────────────── Favorite card (shows author) ─────────────────── */
 function FavoriteCard({ comment }: { comment: CommentData }) {
-  const type     = getCommentType(comment.tags);
-  const nav      = parseBookRef(comment.bookReference ?? "");
-  const initials = getInitials(comment.username || "?");
+	const type = getCommentType(comment.tags);
+	const nav = parseBookRef(comment.bookReference ?? "");
+	const initials = getInitials(comment.username || "?");
 
-  return (
-    <div
-      className="bg-white dark:bg-slate-900 border-l-4 border-y border-r border-slate-200 dark:border-slate-700 rounded-r-[10px] shadow-sm py-3.5 px-[18px]"
-      style={{ borderLeftColor: type.color }}
-    >
-      {/* Header — avatar + username + type badge + verse + date */}
-      <div className="flex items-center gap-2 mb-2.5">
-        {/* Author avatar */}
-        <div className="w-[26px] h-[26px] rounded-[13px] bg-brand-light flex items-center justify-center shrink-0">
-          <span className="font-bold text-[10px] text-brand leading-[15px]">
-            {initials}
-          </span>
-        </div>
-        {/* Username */}
-        <span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 whitespace-nowrap shrink-0">
-          {comment.username}
-        </span>
-        {/* Type badge */}
-        <TagBadges tags={comment.tags} className="shrink-0" />
-        {/* Verse */}
-        {comment.bookReference && (
-          <span className="font-bold text-[11px] text-brand whitespace-nowrap shrink-0">
-            {comment.bookReference}
-          </span>
-        )}
-        {/* Date */}
-        <span className="ml-auto text-[11px] text-slate-400 dark:text-slate-500 whitespace-nowrap">
-          {dateFormat(comment.createdAt)}
-        </span>
-      </div>
+	return (
+		<div
+			className="bg-white dark:bg-slate-900 border-l-4 border-y border-r border-slate-200 dark:border-slate-700 rounded-r-[10px] shadow-sm py-3.5 px-[18px]"
+			style={{ borderLeftColor: type.color }}
+		>
+			{/* Header — avatar + username + type badge + verse + date */}
+			<div className="flex items-center gap-2 mb-2.5">
+				{/* Author avatar */}
+				<div className="w-[26px] h-[26px] rounded-[13px] bg-brand-light flex items-center justify-center shrink-0">
+					<span className="font-bold text-[10px] text-brand leading-[15px]">
+						{initials}
+					</span>
+				</div>
+				{/* Username */}
+				<span className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 whitespace-nowrap shrink-0">
+					{comment.username}
+				</span>
+				{/* Type badge */}
+				<TagBadges tags={comment.tags} className="shrink-0" />
+				{/* Verse */}
+				{comment.bookReference && (
+					<span className="font-bold text-[11px] text-brand whitespace-nowrap shrink-0">
+						{comment.bookReference}
+					</span>
+				)}
+				{/* Date */}
+				<span className="ml-auto text-[11px] text-slate-400 dark:text-slate-500 whitespace-nowrap">
+					{dateFormat(comment.createdAt)}
+				</span>
+			</div>
 
-      {/* Text */}
-      <p className="text-[13px] text-gray-700 dark:text-gray-300 leading-[22.75px] m-0 mb-2.5 line-clamp-2">
-        {comment.text}
-      </p>
+			{/* Text */}
+			<p className="text-[13px] text-gray-700 dark:text-gray-300 leading-[22.75px] m-0 mb-2.5 line-clamp-2">
+				{comment.text}
+			</p>
 
-      {/* Context link */}
-      {nav && (
-        <Link
-          href={`/verses/${nav.abbrev}/${nav.chapter}#${nav.verse}`}
-          className="inline-flex items-center gap-1.5 font-semibold text-[11px] text-brand no-underline hover:underline"
-        >
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-            <polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" />
-          </svg>
-          Ver no contexto ({comment.bookReference})
-        </Link>
-      )}
-    </div>
-  );
+			{/* Context link */}
+			{nav && (
+				<Link
+					href={`/verses/${nav.abbrev}/${nav.chapter}#${nav.verse}`}
+					className="inline-flex items-center gap-1.5 font-semibold text-[11px] text-brand no-underline hover:underline"
+				>
+					<svg
+						width="11"
+						height="11"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+						<polyline points="15 3 21 3 21 9" />
+						<line x1="10" y1="14" x2="21" y2="3" />
+					</svg>
+					Ver no contexto ({comment.bookReference})
+				</Link>
+			)}
+		</div>
+	);
 }
 
 /* ─────────────────── Privacy toggle switch ─────────────────── */
-function PrivacyToggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      onClick={() => onChange(!checked)}
-      className={`shrink-0 w-9 h-5 rounded-[10px] border-none cursor-pointer relative transition-colors duration-200 p-0 mt-px ${
-        checked ? "bg-brand" : "bg-slate-300 dark:bg-slate-600"
-      }`}
-    >
-      <span
-        className={`absolute top-[3px] w-[14px] h-[14px] rounded-[7px] bg-white shadow transition-[left] duration-200 ${
-          checked ? "left-[17px]" : "left-[3px]"
-        }`}
-      />
-    </button>
-  );
+function PrivacyToggle({
+	checked,
+	onChange,
+}: {
+	checked: boolean;
+	onChange: (v: boolean) => void;
+}) {
+	return (
+		<button
+			type="button"
+			role="switch"
+			aria-checked={checked}
+			onClick={() => onChange(!checked)}
+			className={`shrink-0 w-9 h-5 rounded-[10px] border-none cursor-pointer relative transition-colors duration-200 p-0 mt-px ${
+				checked ? "bg-brand" : "bg-slate-300 dark:bg-slate-600"
+			}`}
+		>
+			<span
+				className={`absolute top-[3px] w-[14px] h-[14px] rounded-[7px] bg-white shadow transition-[left] duration-200 ${
+					checked ? "left-[17px]" : "left-[3px]"
+				}`}
+			/>
+		</button>
+	);
 }
 
 /* ─────────────────── Change-password card ─────────────────── */
 function ChangePasswordCard() {
-  const { handleNotification } = useNotification();
-  const [current, setCurrent] = useState("");
-  const [next, setNext] = useState("");
-  const [confirm, setConfirm] = useState("");
-  const [submitting, setSubmitting] = useState(false);
+	const { handleNotification } = useNotification();
+	const [current, setCurrent] = useState("");
+	const [next, setNext] = useState("");
+	const [confirm, setConfirm] = useState("");
+	const [submitting, setSubmitting] = useState(false);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (next.length < 6) {
-      handleNotification("error", "A nova senha deve ter ao menos 6 caracteres.");
-      return;
-    }
-    if (next !== confirm) {
-      handleNotification("error", "A confirmação não bate com a nova senha.");
-      return;
-    }
-    if (next === current) {
-      handleNotification("error", "A nova senha deve ser diferente da atual.");
-      return;
-    }
-    setSubmitting(true);
-    try {
-      await usersService.changePassword(current, next);
-      handleNotification("success", "Senha atualizada.");
-      setCurrent("");
-      setNext("");
-      setConfirm("");
-    } catch (err: unknown) {
-      const status = (err as { response?: { status?: number } })?.response?.status;
-      if (status === 403) handleNotification("error", "Senha atual incorreta.");
-      else if (status === 400) handleNotification("error", "Senha inválida (mínimo 6 caracteres, deve diferir da atual).");
-      else handleNotification("error", "Erro ao atualizar senha.");
-    } finally {
-      setSubmitting(false);
-    }
-  }
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		if (next.length < 6) {
+			handleNotification(
+				"error",
+				"A nova senha deve ter ao menos 6 caracteres.",
+			);
+			return;
+		}
+		if (next !== confirm) {
+			handleNotification("error", "A confirmação não bate com a nova senha.");
+			return;
+		}
+		if (next === current) {
+			handleNotification("error", "A nova senha deve ser diferente da atual.");
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await usersService.changePassword(current, next);
+			handleNotification("success", "Senha atualizada.");
+			setCurrent("");
+			setNext("");
+			setConfirm("");
+		} catch (err: unknown) {
+			const status = (err as { response?: { status?: number } })?.response
+				?.status;
+			if (status === 403) handleNotification("error", "Senha atual incorreta.");
+			else if (status === 400)
+				handleNotification(
+					"error",
+					"Senha inválida (mínimo 6 caracteres, deve diferir da atual).",
+				);
+			else handleNotification("error", "Erro ao atualizar senha.");
+		} finally {
+			setSubmitting(false);
+		}
+	}
 
-  return (
-    <form
-      onSubmit={handleSubmit}
-      className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6"
-    >
-      <div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-4">
-        Trocar senha
-      </div>
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1.5">
-          <label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
-            Senha atual
-          </label>
-          <input
-            type="password"
-            autoComplete="current-password"
-            value={current}
-            onChange={(e) => setCurrent(e.target.value)}
-            className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 text-[13px] outline-none focus:border-brand"
-          />
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
-            Nova senha
-          </label>
-          <input
-            type="password"
-            autoComplete="new-password"
-            value={next}
-            onChange={(e) => setNext(e.target.value)}
-            minLength={6}
-            className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 text-[13px] outline-none focus:border-brand"
-          />
-          <p className="text-[11px] text-slate-400 dark:text-slate-500">Mínimo 6 caracteres.</p>
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
-            Confirmar nova senha
-          </label>
-          <input
-            type="password"
-            autoComplete="new-password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 text-[13px] outline-none focus:border-brand"
-          />
-        </div>
-      </div>
-      <button
-        type="submit"
-        disabled={submitting || !current || !next || !confirm}
-        className="mt-5 h-[35.5px] px-5 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:opacity-90 transition disabled:opacity-50"
-      >
-        {submitting ? "Atualizando…" : "Atualizar senha"}
-      </button>
-    </form>
-  );
+	return (
+		<form
+			onSubmit={handleSubmit}
+			className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6"
+		>
+			<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-4">
+				Trocar senha
+			</div>
+			<div className="flex flex-col gap-3">
+				<div className="flex flex-col gap-1.5">
+					<label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
+						Senha atual
+					</label>
+					<input
+						type="password"
+						autoComplete="current-password"
+						value={current}
+						onChange={(e) => setCurrent(e.target.value)}
+						className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 text-[13px] outline-none focus:border-brand"
+					/>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
+						Nova senha
+					</label>
+					<input
+						type="password"
+						autoComplete="new-password"
+						value={next}
+						onChange={(e) => setNext(e.target.value)}
+						minLength={6}
+						className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 text-[13px] outline-none focus:border-brand"
+					/>
+					<p className="text-[11px] text-slate-400 dark:text-slate-500">
+						Mínimo 6 caracteres.
+					</p>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
+						Confirmar nova senha
+					</label>
+					<input
+						type="password"
+						autoComplete="new-password"
+						value={confirm}
+						onChange={(e) => setConfirm(e.target.value)}
+						className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 rounded-lg px-3 text-[13px] outline-none focus:border-brand"
+					/>
+				</div>
+			</div>
+			<button
+				type="submit"
+				disabled={submitting || !current || !next || !confirm}
+				className="mt-5 h-[35.5px] px-5 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:opacity-90 transition disabled:opacity-50"
+			>
+				{submitting ? "Atualizando…" : "Atualizar senha"}
+			</button>
+		</form>
+	);
 }
 
 /* ─────────────────── Tutorial reset (config tab) ─────────────────── */
 function IdentityCard({
-  initialDisplayName,
-  initialUsername,
-  onUpdated,
+	initialDisplayName,
+	initialUsername,
+	onUpdated,
 }: {
-  initialDisplayName: string;
-  initialUsername: string;
-  onUpdated: (next: { displayName?: string; username?: string }) => void;
+	initialDisplayName: string;
+	initialUsername: string;
+	onUpdated: (next: { displayName?: string; username?: string }) => void;
 }) {
-  const { handleNotification } = useNotification();
-  const { update: updateSession } = useSession();
-  const [displayName, setDisplayName] = useState(initialDisplayName);
-  const [username, setUsername] = useState(initialUsername);
-  const [savingName, setSavingName] = useState(false);
-  const [savingSlug, setSavingSlug] = useState(false);
+	const { handleNotification } = useNotification();
+	const { update: updateSession } = useSession();
+	const [displayName, setDisplayName] = useState(initialDisplayName);
+	const [username, setUsername] = useState(initialUsername);
+	const [savingName, setSavingName] = useState(false);
+	const [savingSlug, setSavingSlug] = useState(false);
 
-  const slugIsValid = /^[a-z0-9_-]{2,40}$/.test(username);
-  const slugChanged = username !== initialUsername;
-  const nameChanged = displayName.trim() !== initialDisplayName.trim();
-  const nameValid = displayName.trim().length >= 1 && displayName.trim().length <= 80;
+	const slugIsValid = /^[a-z0-9_-]{2,40}$/.test(username);
+	const slugChanged = username !== initialUsername;
+	const nameChanged = displayName.trim() !== initialDisplayName.trim();
+	const nameValid =
+		displayName.trim().length >= 1 && displayName.trim().length <= 80;
 
-  async function saveName() {
-    if (!nameChanged || !nameValid) return;
-    setSavingName(true);
-    try {
-      const trimmed = displayName.trim();
-      await usersService.updateProfile({ displayName: trimmed });
-      // Refresh the JWT in place so AuthMenu/profile header pick up the
-      // new name without a re-login.
-      await updateSession({ displayName: trimmed, name: trimmed });
-      onUpdated({ displayName: trimmed });
-      handleNotification("success", "Nome atualizado.");
-    } catch {
-      handleNotification("error", "Erro ao atualizar nome.");
-    } finally {
-      setSavingName(false);
-    }
-  }
+	async function saveName() {
+		if (!nameChanged || !nameValid) return;
+		setSavingName(true);
+		try {
+			const trimmed = displayName.trim();
+			await usersService.updateProfile({ displayName: trimmed });
+			// Refresh the JWT in place so AuthMenu/profile header pick up the
+			// new name without a re-login.
+			await updateSession({ displayName: trimmed, name: trimmed });
+			onUpdated({ displayName: trimmed });
+			handleNotification("success", "Nome atualizado.");
+		} catch {
+			handleNotification("error", "Erro ao atualizar nome.");
+		} finally {
+			setSavingName(false);
+		}
+	}
 
-  async function saveSlug() {
-    if (!slugChanged || !slugIsValid) return;
-    setSavingSlug(true);
-    try {
-      const result = await usersService.updateUsername(username);
-      // Update the JWT so subsequent writes (createCommentAction, etc.)
-      // attribute records to the new slug instead of the now-defunct one.
-      await updateSession({ username: result.username });
-      onUpdated({ username: result.username });
-      handleNotification("success", "Identificador atualizado.");
-    } catch (err) {
-      const msg = (err as Error)?.message ?? "Erro ao atualizar identificador.";
-      if (msg === "Username already taken") {
-        handleNotification("error", "Esse identificador já está em uso.");
-      } else if (msg === "Invalid username format") {
-        handleNotification("error", "Formato inválido.");
-      } else {
-        handleNotification("error", "Erro ao atualizar identificador.");
-      }
-    } finally {
-      setSavingSlug(false);
-    }
-  }
+	async function saveSlug() {
+		if (!slugChanged || !slugIsValid) return;
+		setSavingSlug(true);
+		try {
+			const result = await usersService.updateUsername(username);
+			// Update the JWT so subsequent writes (createCommentAction, etc.)
+			// attribute records to the new slug instead of the now-defunct one.
+			await updateSession({ username: result.username });
+			onUpdated({ username: result.username });
+			handleNotification("success", "Identificador atualizado.");
+		} catch (err) {
+			const msg = (err as Error)?.message ?? "Erro ao atualizar identificador.";
+			if (msg === "Username already taken") {
+				handleNotification("error", "Esse identificador já está em uso.");
+			} else if (msg === "Invalid username format") {
+				handleNotification("error", "Formato inválido.");
+			} else {
+				handleNotification("error", "Erro ao atualizar identificador.");
+			}
+		} finally {
+			setSavingSlug(false);
+		}
+	}
 
-  return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
-      <div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-2">
-        Identidade
-      </div>
-      <p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-5 mt-0">
-        Seu nome aparece nos comentários. O identificador único é usado em URLs
-        e para login — só letras minúsculas, números, hífen ou sublinhado.
-      </p>
+	return (
+		<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
+			<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-2">
+				Identidade
+			</div>
+			<p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-5 mt-0">
+				Seu nome aparece nos comentários. O identificador único é usado em URLs
+				e para login — só letras minúsculas, números, hífen ou sublinhado.
+			</p>
 
-      <div className="flex flex-col gap-1.5 mb-4">
-        <label htmlFor="profile-displayname" className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
-          Nome
-        </label>
-        <div className="flex gap-2">
-          <input
-            id="profile-displayname"
-            type="text"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            maxLength={80}
-            className="flex-1 h-[38.833px] border border-slate-200 dark:border-slate-700 rounded-lg px-3 text-[13px] text-slate-800 dark:text-slate-100 bg-white dark:bg-slate-900 outline-none"
-          />
-          <button
-            type="button"
-            onClick={saveName}
-            disabled={!nameChanged || !nameValid || savingName}
-            className="h-[38.833px] px-4 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {savingName ? "…" : "Salvar"}
-          </button>
-        </div>
-      </div>
+			<div className="flex flex-col gap-1.5 mb-4">
+				<label
+					htmlFor="profile-displayname"
+					className="font-semibold text-[13px] text-slate-800 dark:text-slate-100"
+				>
+					Nome
+				</label>
+				<div className="flex gap-2">
+					<input
+						id="profile-displayname"
+						type="text"
+						value={displayName}
+						onChange={(e) => setDisplayName(e.target.value)}
+						maxLength={80}
+						className="flex-1 h-[38.833px] border border-slate-200 dark:border-slate-700 rounded-lg px-3 text-[13px] text-slate-800 dark:text-slate-100 bg-white dark:bg-slate-900 outline-none"
+					/>
+					<button
+						type="button"
+						onClick={saveName}
+						disabled={!nameChanged || !nameValid || savingName}
+						className="h-[38.833px] px-4 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+					>
+						{savingName ? "…" : "Salvar"}
+					</button>
+				</div>
+			</div>
 
-      <div className="flex flex-col gap-1.5">
-        <label htmlFor="profile-username" className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
-          Identificador único (@)
-        </label>
-        <div className="flex gap-2">
-          <div className="flex-1 flex items-center border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
-            <span className="pl-3 pr-1 text-slate-400 dark:text-slate-500 text-[13px]">@</span>
-            <input
-              id="profile-username"
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value.toLowerCase())}
-              maxLength={40}
-              className="flex-1 h-[38.833px] pr-3 text-[13px] text-slate-800 dark:text-slate-100 bg-transparent outline-none"
-            />
-          </div>
-          <button
-            type="button"
-            onClick={saveSlug}
-            disabled={!slugChanged || !slugIsValid || savingSlug}
-            className="h-[38.833px] px-4 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {savingSlug ? "…" : "Salvar"}
-          </button>
-        </div>
-        {slugChanged && !slugIsValid && (
-          <p className="text-xs text-red-500 dark:text-red-400 mt-1">
-            Use 2–40 caracteres: letras minúsculas, números, hífen ou sublinhado.
-          </p>
-        )}
-      </div>
-    </div>
-  );
+			<div className="flex flex-col gap-1.5">
+				<label
+					htmlFor="profile-username"
+					className="font-semibold text-[13px] text-slate-800 dark:text-slate-100"
+				>
+					Identificador único (@)
+				</label>
+				<div className="flex gap-2">
+					<div className="flex-1 flex items-center border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+						<span className="pl-3 pr-1 text-slate-400 dark:text-slate-500 text-[13px]">
+							@
+						</span>
+						<input
+							id="profile-username"
+							type="text"
+							value={username}
+							onChange={(e) => setUsername(e.target.value.toLowerCase())}
+							maxLength={40}
+							className="flex-1 h-[38.833px] pr-3 text-[13px] text-slate-800 dark:text-slate-100 bg-transparent outline-none"
+						/>
+					</div>
+					<button
+						type="button"
+						onClick={saveSlug}
+						disabled={!slugChanged || !slugIsValid || savingSlug}
+						className="h-[38.833px] px-4 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+					>
+						{savingSlug ? "…" : "Salvar"}
+					</button>
+				</div>
+				{slugChanged && !slugIsValid && (
+					<p className="text-xs text-red-500 dark:text-red-400 mt-1">
+						Use 2–40 caracteres: letras minúsculas, números, hífen ou
+						sublinhado.
+					</p>
+				)}
+			</div>
+		</div>
+	);
 }
 
-function MyDataCard({ onCommentsImported }: { onCommentsImported: () => void }) {
-  const { handleNotification } = useNotification();
-  const confirm = useConfirm();
-  const fileRef = useRef<HTMLInputElement>(null);
-  const [importing, setImporting] = useState(false);
+function MyDataCard({
+	onCommentsImported,
+}: {
+	onCommentsImported: () => void;
+}) {
+	const { handleNotification } = useNotification();
+	const confirm = useConfirm();
+	const fileRef = useRef<HTMLInputElement>(null);
+	const [importing, setImporting] = useState(false);
 
-  const onPick = () => fileRef.current?.click();
+	const onPick = () => fileRef.current?.click();
 
-  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (fileRef.current) fileRef.current.value = "";
-    if (!file) return;
+	const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (fileRef.current) fileRef.current.value = "";
+		if (!file) return;
 
-    const ok = await confirm({
-      title: "Importar comentários do backup?",
-      description:
-        "Comentários idênticos aos seus já existentes serão ignorados. " +
-        "Comentários cujo versículo não exista no banco atual serão pulados.",
-      confirmLabel: "Importar",
-    });
-    if (!ok) return;
+		const ok = await confirm({
+			title: "Importar comentários do backup?",
+			description:
+				"Comentários idênticos aos seus já existentes serão ignorados. " +
+				"Comentários cujo versículo não exista no banco atual serão pulados.",
+			confirmLabel: "Importar",
+		});
+		if (!ok) return;
 
-    setImporting(true);
-    try {
-      const text = await file.text();
-      const payload = JSON.parse(text);
-      const result = await usersService.importMyComments(payload);
-      onCommentsImported();
-      handleNotification(
-        "success",
-        `Importação concluída: ${result.imported} novos, ${result.skipped} já existiam, ${result.failed} ignorados.`,
-      );
-    } catch (err) {
-      const status = (err as { response?: { status?: number } })?.response?.status;
-      if (status === 400) {
-        handleNotification("error", "Arquivo inválido. Use um JSON exportado pelo próprio Bible Comment.");
-      } else {
-        handleNotification("error", "Não foi possível importar o arquivo.");
-      }
-    } finally {
-      setImporting(false);
-    }
-  };
+		setImporting(true);
+		try {
+			const text = await file.text();
+			const payload = JSON.parse(text);
+			const result = await usersService.importMyComments(payload);
+			onCommentsImported();
+			handleNotification(
+				"success",
+				`Importação concluída: ${result.imported} novos, ${result.skipped} já existiam, ${result.failed} ignorados.`,
+			);
+		} catch (err) {
+			const status = (err as { response?: { status?: number } })?.response
+				?.status;
+			if (status === 400) {
+				handleNotification(
+					"error",
+					"Arquivo inválido. Use um JSON exportado pelo próprio Bible Comment.",
+				);
+			} else {
+				handleNotification("error", "Não foi possível importar o arquivo.");
+			}
+		} finally {
+			setImporting(false);
+		}
+	};
 
-  return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
-      <div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-2">
-        Meus dados
-      </div>
-      <p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-4 mt-0">
-        Baixe um arquivo JSON com tudo que armazenamos sobre você (perfil,
-        comentários, discussões, respostas e notificações). Você pode também
-        restaurar comentários a partir de um backup anterior.
-      </p>
-      <div className="flex flex-wrap gap-2">
-        <a
-          href="/api/users/me/export"
-          className="inline-block h-[35.5px] px-5 leading-[35.5px] bg-transparent text-brand border-[1.333px] border-brand rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:bg-brand-wash transition"
-        >
-          Exportar meus dados (JSON)
-        </a>
-        <button
-          type="button"
-          onClick={onPick}
-          disabled={importing}
-          className="h-[35.5px] px-5 bg-transparent text-brand border-[1.333px] border-brand rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:bg-brand-wash transition disabled:opacity-50"
-        >
-          {importing ? "Importando…" : "Importar comentários (JSON)"}
-        </button>
-        <label htmlFor="profile-import-file" className="sr-only">
-          Selecionar arquivo de backup JSON
-        </label>
-        <input
-          id="profile-import-file"
-          ref={fileRef}
-          type="file"
-          accept="application/json,.json"
-          onChange={onFile}
-          className="hidden"
-        />
-      </div>
-    </div>
-  );
+	return (
+		<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
+			<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-2">
+				Meus dados
+			</div>
+			<p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-4 mt-0">
+				Baixe um arquivo JSON com tudo que armazenamos sobre você (perfil,
+				comentários, discussões, respostas e notificações). Você pode também
+				restaurar comentários a partir de um backup anterior.
+			</p>
+			<div className="flex flex-wrap gap-2">
+				<a
+					href="/api/users/me/export"
+					className="inline-block h-[35.5px] px-5 leading-[35.5px] bg-transparent text-brand border-[1.333px] border-brand rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:bg-brand-wash transition"
+				>
+					Exportar meus dados (JSON)
+				</a>
+				<button
+					type="button"
+					onClick={onPick}
+					disabled={importing}
+					className="h-[35.5px] px-5 bg-transparent text-brand border-[1.333px] border-brand rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:bg-brand-wash transition disabled:opacity-50"
+				>
+					{importing ? "Importando…" : "Importar comentários (JSON)"}
+				</button>
+				<label htmlFor="profile-import-file" className="sr-only">
+					Selecionar arquivo de backup JSON
+				</label>
+				<input
+					id="profile-import-file"
+					ref={fileRef}
+					type="file"
+					accept="application/json,.json"
+					onChange={onFile}
+					className="hidden"
+				/>
+			</div>
+		</div>
+	);
 }
 
 function TutorialResetCard() {
-  const router = useRouter();
-  const tutorial = useTutorial(CHAPTER_TUTORIAL_NAME);
-  return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
-      <div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-2">
-        Tutorial guiado
-      </div>
-      <p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-4 mt-0">
-        Refaça o tour de boas-vindas para revisar como ler, comentar, abrir
-        discussões e gerenciar sua conta.
-      </p>
-      <button
-        type="button"
-        onClick={() => {
-          tutorial.reset();
-          router.push("/chapter/jo/3?tour=1");
-        }}
-        className="h-[35.5px] px-5 bg-transparent text-brand border-[1.333px] border-brand rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:bg-brand-wash transition"
-      >
-        Refazer tutorial
-      </button>
-    </div>
-  );
+	const router = useRouter();
+	const tutorial = useTutorial(CHAPTER_TUTORIAL_NAME);
+	return (
+		<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
+			<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-2">
+				Tutorial guiado
+			</div>
+			<p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-4 mt-0">
+				Refaça o tour de boas-vindas para revisar como ler, comentar, abrir
+				discussões e gerenciar sua conta.
+			</p>
+			<button
+				type="button"
+				onClick={() => {
+					tutorial.reset();
+					router.push("/chapter/jo/3?tour=1");
+				}}
+				className="h-[35.5px] px-5 bg-transparent text-brand border-[1.333px] border-brand rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer hover:bg-brand-wash transition"
+			>
+				Refazer tutorial
+			</button>
+		</div>
+	);
 }
 
 /* ─────────────────── Stat card (overview) ─────────────────── */
-function StatCard({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
-  const pct = max > 0 ? Math.min(100, Math.round((value / max) * 100)) : 0;
-  return (
-    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 sm:px-6 py-4 sm:py-5 flex-1 min-w-0">
-      <div
-        className="text-[28px] font-extrabold leading-none"
-        style={{ color }}
-      >
-        {value.toLocaleString("pt-BR")}
-      </div>
-      <div className={`text-xs text-slate-400 dark:text-slate-500 mt-1 ${max > 0 ? "mb-3" : ""}`}>
-        {label}
-        {max > 0 && <span className="text-slate-300 dark:text-slate-600"> de {max.toLocaleString("pt-BR")}</span>}
-      </div>
-      {max > 0 && (
-        <div className="h-1 bg-slate-100 dark:bg-slate-800 rounded-sm overflow-hidden">
-          <div
-            className="h-full rounded-sm transition-[width] duration-500 ease-out"
-            style={{ width: `${pct}%`, background: color }}
-          />
-        </div>
-      )}
-    </div>
-  );
+function StatCard({
+	label,
+	value,
+	max,
+	color,
+}: {
+	label: string;
+	value: number;
+	max: number;
+	color: string;
+}) {
+	const pct = max > 0 ? Math.min(100, Math.round((value / max) * 100)) : 0;
+	return (
+		<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 sm:px-6 py-4 sm:py-5 flex-1 min-w-0">
+			<div
+				className="text-[28px] font-extrabold leading-none"
+				style={{ color }}
+			>
+				{value.toLocaleString("pt-BR")}
+			</div>
+			<div
+				className={`text-xs text-slate-400 dark:text-slate-500 mt-1 ${max > 0 ? "mb-3" : ""}`}
+			>
+				{label}
+				{max > 0 && (
+					<span className="text-slate-300 dark:text-slate-600">
+						{" "}
+						de {max.toLocaleString("pt-BR")}
+					</span>
+				)}
+			</div>
+			{max > 0 && (
+				<div className="h-1 bg-slate-100 dark:bg-slate-800 rounded-sm overflow-hidden">
+					<div
+						className="h-full rounded-sm transition-[width] duration-500 ease-out"
+						style={{ width: `${pct}%`, background: color }}
+					/>
+				</div>
+			)}
+		</div>
+	);
 }
 
 /* ─────────────────── Sidebar nav items ─────────────────── */
 const NAV_ITEMS: { id: Tab; label: string; icon: React.ReactNode }[] = [
-  {
-    id: "overview",
-    label: "Visão Geral",
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" />
-        <rect x="14" y="14" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
-      </svg>
-    ),
-  },
-  {
-    id: "comments",
-    label: "Meus Comentários",
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-      </svg>
-    ),
-  },
-  {
-    id: "favorites",
-    label: "Favoritos",
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-      </svg>
-    ),
-  },
-  {
-    id: "badges",
-    label: "Conquistas",
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="8" r="6" />
-        <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
-      </svg>
-    ),
-  },
-  {
-    id: "config",
-    label: "Configurações",
-    icon: (
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="12" r="3" />
-        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-      </svg>
-    ),
-  },
+	{
+		id: "overview",
+		label: "Visão Geral",
+		icon: (
+			<svg
+				width="15"
+				height="15"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<rect x="3" y="3" width="7" height="7" />
+				<rect x="14" y="3" width="7" height="7" />
+				<rect x="14" y="14" width="7" height="7" />
+				<rect x="3" y="14" width="7" height="7" />
+			</svg>
+		),
+	},
+	{
+		id: "comments",
+		label: "Meus Comentários",
+		icon: (
+			<svg
+				width="15"
+				height="15"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+			</svg>
+		),
+	},
+	{
+		id: "favorites",
+		label: "Favoritos",
+		icon: (
+			<svg
+				width="15"
+				height="15"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+			</svg>
+		),
+	},
+	{
+		id: "badges",
+		label: "Conquistas",
+		icon: (
+			<svg
+				width="15"
+				height="15"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<circle cx="12" cy="8" r="6" />
+				<polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
+			</svg>
+		),
+	},
+	{
+		id: "config",
+		label: "Configurações",
+		icon: (
+			<svg
+				width="15"
+				height="15"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			>
+				<circle cx="12" cy="12" r="3" />
+				<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+			</svg>
+		),
+	},
 ];
 
 /* ──────────────────────── Main component ──────────────────────── */
 export default function ProfileClient({ user }: { user: SessionUser }) {
-  const { handleNotification } = useNotification();
-  const confirm = useConfirm();
-  const [tab, setTab]               = useState<Tab>("overview");
-  const [profile, setProfile]       = useState<UserProfile | null>(null);
-  const [comments, setComments]     = useState<CommentData[]>([]);
-  const [favorites, setFavorites]   = useState<CommentData[]>([]);
-  const [loading, setLoading]       = useState(false);
-  const [belief, setBelief]           = useState("");
-  const [stateName, setStateName]     = useState("");
-  // showReligion drives the public profile's belief visibility — opt-in,
-  // default false. Loaded from /api/users/me and persisted on save below.
-  const [showReligion, setShowReligion]       = useState(false);
-  const [showHistory, setShowHistory]         = useState(true);
-  const [editingComment, setEditingComment] = useState<CommentData | null>(null);
-  const [commentSearch, setCommentSearch]   = useState("");
-  const [favSearch, setFavSearch]           = useState("");
-  const [favTypeFilter, setFavTypeFilter]   = useState<TypeFilter>("Todos");
+	const { handleNotification } = useNotification();
+	const confirm = useConfirm();
+	const [tab, setTab] = useState<Tab>("overview");
+	const [profile, setProfile] = useState<UserProfile | null>(null);
+	const [comments, setComments] = useState<CommentData[]>([]);
+	const [favorites, setFavorites] = useState<CommentData[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [belief, setBelief] = useState("");
+	const [stateName, setStateName] = useState("");
+	// showReligion drives the public profile's belief visibility — opt-in,
+	// default false. Loaded from /api/users/me and persisted on save below.
+	const [showReligion, setShowReligion] = useState(false);
+	const [showHistory, setShowHistory] = useState(true);
+	const [editingComment, setEditingComment] = useState<CommentData | null>(
+		null,
+	);
+	const [commentSearch, setCommentSearch] = useState("");
+	const [favSearch, setFavSearch] = useState("");
+	const [favTypeFilter, setFavTypeFilter] = useState<TypeFilter>("Todos");
 
-  const initials = getInitials(user.name || user.username);
+	const initials = getInitials(user.name || user.username);
 
-  /* ── Data loaders ── */
-  const loadProfile = useCallback(async () => {
-    try {
-      const data = await usersService.getMe();
-      setProfile(data);
-      setBelief(data.belief ?? "");
-      setStateName(data.stateName ?? "");
-      setShowReligion(data.showBelief ?? false);
-    } catch {
-      handleNotification("error", "Erro ao carregar perfil.");
-    }
-  }, [handleNotification]);
+	/* ── Data loaders ── */
+	const loadProfile = useCallback(async () => {
+		try {
+			const data = await usersService.getMe();
+			setProfile(data);
+			setBelief(data.belief ?? "");
+			setStateName(data.stateName ?? "");
+			setShowReligion(data.showBelief ?? false);
+		} catch {
+			handleNotification("error", "Erro ao carregar perfil.");
+		}
+	}, [handleNotification]);
 
-  const loadComments = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = (await usersService.listMyComments()) as unknown as CommentData[];
-      setComments(data);
-    } catch {
-      handleNotification("error", "Erro ao carregar comentários.");
-    } finally {
-      setLoading(false);
-    }
-  }, [handleNotification]);
+	const loadComments = useCallback(async () => {
+		setLoading(true);
+		try {
+			const data =
+				(await usersService.listMyComments()) as unknown as CommentData[];
+			setComments(data);
+		} catch {
+			handleNotification("error", "Erro ao carregar comentários.");
+		} finally {
+			setLoading(false);
+		}
+	}, [handleNotification]);
 
-  const loadFavorites = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = (await usersService.listMyFavorites()) as unknown as CommentData[];
-      setFavorites(data);
-    } catch {
-      handleNotification("error", "Erro ao carregar favoritos.");
-    } finally {
-      setLoading(false);
-    }
-  }, [handleNotification]);
+	const loadFavorites = useCallback(async () => {
+		setLoading(true);
+		try {
+			const data =
+				(await usersService.listMyFavorites()) as unknown as CommentData[];
+			setFavorites(data);
+		} catch {
+			handleNotification("error", "Erro ao carregar favoritos.");
+		} finally {
+			setLoading(false);
+		}
+	}, [handleNotification]);
 
-  useEffect(() => { loadProfile(); loadComments(); }, [loadProfile, loadComments]);
-  useEffect(() => { if (tab === "favorites" && favorites.length === 0) loadFavorites(); }, [tab, favorites.length, loadFavorites]);
+	useEffect(() => {
+		loadProfile();
+		loadComments();
+	}, [loadProfile, loadComments]);
+	useEffect(() => {
+		if (tab === "favorites" && favorites.length === 0) loadFavorites();
+	}, [tab, favorites.length, loadFavorites]);
 
-  /* ── Handlers ── */
-  const handleDelete = useCallback(async (id: string) => {
-    const ok = await confirm({
-      title: "Excluir este comentário?",
-      description: "Esta ação não pode ser desfeita.",
-      confirmLabel: "Excluir",
-      variant: "danger",
-    });
-    if (!ok) return;
-    try {
-      await commentsService.delete(id);
-      setComments(prev => prev.filter(c => c._id !== id));
-      handleNotification("success", "Comentário excluído.");
-    } catch {
-      handleNotification("error", "Erro ao excluir.");
-    }
-  }, [handleNotification, confirm]);
+	/* ── Handlers ── */
+	const handleDelete = useCallback(
+		async (id: string) => {
+			const ok = await confirm({
+				title: "Excluir este comentário?",
+				description: "Esta ação não pode ser desfeita.",
+				confirmLabel: "Excluir",
+				variant: "danger",
+			});
+			if (!ok) return;
+			try {
+				await commentsService.delete(id);
+				setComments((prev) => prev.filter((c) => c._id !== id));
+				handleNotification("success", "Comentário excluído.");
+			} catch {
+				handleNotification("error", "Erro ao excluir.");
+			}
+		},
+		[handleNotification, confirm],
+	);
 
-  const handleUpdateAccount = useCallback(async () => {
-    try {
-      await usersService.updateProfile({
-        belief,
-        state: stateName,
-        showBelief: showReligion,
-      });
-      handleNotification("success", "Conta atualizada!");
-    } catch {
-      handleNotification("error", "Erro ao atualizar.");
-    }
-  }, [belief, stateName, showReligion, handleNotification]);
+	const handleUpdateAccount = useCallback(async () => {
+		try {
+			await usersService.updateProfile({
+				belief,
+				state: stateName,
+				showBelief: showReligion,
+			});
+			handleNotification("success", "Conta atualizada!");
+		} catch {
+			handleNotification("error", "Erro ao atualizar.");
+		}
+	}, [belief, stateName, showReligion, handleNotification]);
 
-  const handleDeleteAccount = useCallback(async () => {
-    const ok = await confirm({
-      title: "Excluir sua conta?",
-      description: "Esta ação é irreversível. Seus dados pessoais serão removidos e seus comentários ficarão anônimos.",
-      confirmLabel: "Excluir conta",
-      variant: "danger",
-    });
-    if (!ok) return;
-    try {
-      await usersService.deleteSelf(user.email);
-      handleNotification("success", "Conta excluída.");
-      await signOut({ callbackUrl: "/login" });
-    } catch {
-      handleNotification("error", "Erro ao excluir conta.");
-    }
-  }, [handleNotification, user.email, confirm]);
+	const handleDeleteAccount = useCallback(async () => {
+		const ok = await confirm({
+			title: "Excluir sua conta?",
+			description:
+				"Esta ação é irreversível. Seus dados pessoais serão removidos e seus comentários ficarão anônimos.",
+			confirmLabel: "Excluir conta",
+			variant: "danger",
+		});
+		if (!ok) return;
+		try {
+			await usersService.deleteSelf(user.email);
+			handleNotification("success", "Conta excluída.");
+			await signOut({ callbackUrl: "/login" });
+		} catch {
+			handleNotification("error", "Erro ao excluir conta.");
+		}
+	}, [handleNotification, user.email, confirm]);
 
-  /* ── Derived data ── */
-  const filteredComments = useMemo(() => {
-    if (!commentSearch) return comments;
-    const q = commentSearch.toLowerCase();
-    return comments.filter(c =>
-      c.text.toLowerCase().includes(q) || (c.bookReference ?? "").toLowerCase().includes(q)
-    );
-  }, [comments, commentSearch]);
+	/* ── Derived data ── */
+	const filteredComments = useMemo(() => {
+		if (!commentSearch) return comments;
+		const q = commentSearch.toLowerCase();
+		return comments.filter(
+			(c) =>
+				c.text.toLowerCase().includes(q) ||
+				(c.bookReference ?? "").toLowerCase().includes(q),
+		);
+	}, [comments, commentSearch]);
 
-  const filteredFavorites = useMemo(() => {
-    let list = favorites;
-    if (favTypeFilter !== "Todos") {
-      // Match if ANY of the comment's categories equals the filter (a
-      // multi-tag comment shows up under each of its categories).
-      list = list.filter(c =>
-        getTagMetas(c.tags).some(m => m.label === favTypeFilter),
-      );
-    }
-    if (favSearch) {
-      const q = favSearch.toLowerCase();
-      list = list.filter(c =>
-        c.text.toLowerCase().includes(q) ||
-        (c.bookReference ?? "").toLowerCase().includes(q) ||
-        (c.username ?? "").toLowerCase().includes(q)
-      );
-    }
-    return list;
-  }, [favorites, favTypeFilter, favSearch]);
+	const filteredFavorites = useMemo(() => {
+		let list = favorites;
+		if (favTypeFilter !== "Todos") {
+			// Match if ANY of the comment's categories equals the filter (a
+			// multi-tag comment shows up under each of its categories).
+			list = list.filter((c) =>
+				getTagMetas(c.tags).some((m) => m.label === favTypeFilter),
+			);
+		}
+		if (favSearch) {
+			const q = favSearch.toLowerCase();
+			list = list.filter(
+				(c) =>
+					c.text.toLowerCase().includes(q) ||
+					(c.bookReference ?? "").toLowerCase().includes(q) ||
+					(c.username ?? "").toLowerCase().includes(q),
+			);
+		}
+		return list;
+	}, [favorites, favTypeFilter, favSearch]);
 
-  /** Unique authors from favorites, sorted by how many favorited comments they have */
-  const favoriteAuthors = useMemo(() => {
-    const counts: Record<string, number> = {};
-    favorites.forEach(c => { if (c.username) counts[c.username] = (counts[c.username] ?? 0) + 1; });
-    return Object.entries(counts)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 6)
-      .map(([username, count]) => ({ username, count }));
-  }, [favorites]);
+	/** Unique authors from favorites, sorted by how many favorited comments they have */
+	const favoriteAuthors = useMemo(() => {
+		const counts: Record<string, number> = {};
+		favorites.forEach((c) => {
+			if (c.username) counts[c.username] = (counts[c.username] ?? 0) + 1;
+		});
+		return Object.entries(counts)
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, 6)
+			.map(([username, count]) => ({ username, count }));
+	}, [favorites]);
 
-  /* ── Render ── */
-  return (
-    <div className="min-h-screen bg-[#f9f9f7] dark:bg-slate-950">
+	/* ── Render ── */
+	return (
+		<div className="min-h-screen bg-[#f9f9f7] dark:bg-slate-950">
+			<AppHeader user={user} />
 
-      <AppHeader user={user} />
+			{/* ── Body ── */}
+			<div className="max-w-[1100px] mx-auto pt-6 md:pt-8 px-4 md:px-6 pb-16 flex flex-col md:flex-row gap-4 md:gap-6 items-stretch md:items-start">
+				{/* Sidebar */}
+				<aside className="w-full md:w-60 flex-shrink-0 flex flex-col gap-2">
+					{/* User card */}
+					<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl pt-6 px-5 pb-5">
+						<div className="w-[68px] h-[68px] rounded-[34px] bg-brand/15 border-[2.667px] border-[rgba(19,125,219,0.19)] flex items-center justify-center mb-[18px]">
+							<span className="font-extrabold text-[22px] text-brand leading-none">
+								{initials}
+							</span>
+						</div>
+						<div className="font-bold text-base text-slate-800 dark:text-slate-100 leading-6 mb-0.5">
+							{profile?.displayName ?? user.name}
+						</div>
+						<div className="text-xs text-slate-400 dark:text-slate-500 leading-[18px] mb-3">
+							@{profile?.username ?? user.username}
+						</div>
+						{profile?.belief && (
+							<div className="inline-flex items-center bg-brand-tint rounded-xl px-2.5 py-0.5 mb-2">
+								<span className="font-semibold text-[11px] text-brand leading-[16.5px] whitespace-nowrap">
+									{profile.belief}
+								</span>
+							</div>
+						)}
+						{profile?.createdAt && (
+							<div className="text-[11px] text-slate-300 dark:text-slate-600 leading-[16.5px]">
+								Membro desde {formatMemberSince(profile.createdAt)}
+							</div>
+						)}
+					</div>
 
+					{/* Navigation — icon-only tabs on mobile, full sidebar on md+ */}
+					<nav
+						aria-label="Seções do perfil"
+						className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl py-[6.667px] px-[8.667px] flex flex-row md:flex-col gap-0.5 justify-around md:justify-start"
+					>
+						{NAV_ITEMS.map(({ id, label, icon }) => {
+							const active = tab === id;
+							return (
+								<button
+									key={id}
+									type="button"
+									onClick={() => setTab(id)}
+									aria-label={label}
+									title={label}
+									aria-current={active ? "page" : undefined}
+									className={`flex items-center justify-center md:justify-start gap-0 md:gap-2.5 h-[37.5px] w-[37.5px] md:h-[37.5px] md:w-full md:pl-3 md:pr-3 rounded-md border-none cursor-pointer transition-colors ${
+										active
+											? "bg-brand-wash text-brand"
+											: "bg-transparent text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800"
+									}`}
+								>
+									<span className="flex items-center shrink-0">{icon}</span>
+									<span
+										className={`hidden md:inline text-[13px] leading-[19.5px] whitespace-nowrap ${
+											active ? "font-semibold" : "font-normal"
+										}`}
+									>
+										{label}
+									</span>
+								</button>
+							);
+						})}
+						{user.moderator && (
+							<Link
+								href="/admin/moderation"
+								aria-label="Moderação"
+								title="Moderação"
+								className="flex items-center justify-center md:justify-start gap-0 md:gap-2.5 h-[37.5px] w-[37.5px] md:h-[37.5px] md:w-full md:pl-3 md:pr-3 rounded-md no-underline transition-colors text-amber-700 dark:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/20"
+							>
+								<span className="flex items-center shrink-0">
+									<svg
+										width="15"
+										height="15"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="2"
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									>
+										<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+									</svg>
+								</span>
+								<span className="hidden md:inline text-[13px] leading-[19.5px] whitespace-nowrap font-semibold">
+									Moderação
+								</span>
+							</Link>
+						)}
+					</nav>
+				</aside>
 
-      {/* ── Body ── */}
-      <div className="max-w-[1100px] mx-auto pt-6 md:pt-8 px-4 md:px-6 pb-16 flex flex-col md:flex-row gap-4 md:gap-6 items-stretch md:items-start">
+				{/* ── Main content ── */}
+				<main id="main-content" className="flex-1 min-w-0">
+					{/* OVERVIEW */}
+					{tab === "overview" && (
+						<div>
+							<div className="mb-6">
+								<h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0 mb-1">
+									Olá, {user.name.split(" ")[0]} 👋
+								</h2>
+								<p className="text-[13px] text-slate-400 dark:text-slate-500 m-0">
+									Aqui está um resumo da sua atividade no BibleComment.
+								</p>
+							</div>
+							{profile ? (
+								<>
+									<div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-3">
+										<StatCard
+											label="Comentários"
+											value={profile.commentsCount}
+											max={0}
+											color="#137ddb"
+										/>
+										<StatCard
+											label="Livros comentados"
+											value={profile.booksCount}
+											max={66}
+											color="#7c3aed"
+										/>
+										<StatCard
+											label="Capítulos comentados"
+											value={profile.chaptersCount}
+											max={1189}
+											color="#059669"
+										/>
+									</div>
+									<div
+										className="grid grid-cols-2 gap-3 mb-7"
+										data-testid="profile-social-stats"
+									>
+										<Link
+											href={`/u/${user.username}/followers`}
+											data-testid="profile-followers-link"
+											className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4 hover:border-brand transition no-underline"
+										>
+											<div className="text-[11px] uppercase tracking-wider font-semibold text-slate-400 dark:text-slate-500">
+												Seguidores
+											</div>
+											<div className="text-2xl font-bold text-slate-800 dark:text-slate-100 mt-1">
+												{profile.followersCount ?? 0}
+											</div>
+											<div className="text-[11px] text-brand mt-1">
+												Ver lista →
+											</div>
+										</Link>
+										<Link
+											href={`/u/${user.username}/following`}
+											data-testid="profile-following-link"
+											className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4 hover:border-brand transition no-underline"
+										>
+											<div className="text-[11px] uppercase tracking-wider font-semibold text-slate-400 dark:text-slate-500">
+												Seguindo
+											</div>
+											<div className="text-2xl font-bold text-slate-800 dark:text-slate-100 mt-1">
+												{profile.followingCount ?? 0}
+											</div>
+											<div className="text-[11px] text-brand mt-1">
+												Ver lista →
+											</div>
+										</Link>
+									</div>
+								</>
+							) : (
+								<Loading />
+							)}
+							{comments.length > 0 && (
+								<div>
+									<div className="flex items-center justify-between mb-3">
+										<h3 className="font-semibold text-xs text-slate-400 dark:text-slate-500 m-0 uppercase tracking-wider">
+											Comentários recentes
+										</h3>
+										<button
+											type="button"
+											onClick={() => setTab("comments")}
+											className="text-xs text-brand bg-transparent border-none cursor-pointer hover:underline"
+										>
+											Ver todos
+										</button>
+									</div>
+									<div className="flex flex-col gap-2.5">
+										{comments.slice(0, 3).map((c) => (
+											<ProfileCommentCard key={c._id} comment={c} />
+										))}
+									</div>
+								</div>
+							)}
+						</div>
+					)}
 
-        {/* Sidebar */}
-        <aside className="w-full md:w-60 flex-shrink-0 flex flex-col gap-2">
-          {/* User card */}
-          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl pt-6 px-5 pb-5">
-            <div className="w-[68px] h-[68px] rounded-[34px] bg-brand/15 border-[2.667px] border-[rgba(19,125,219,0.19)] flex items-center justify-center mb-[18px]">
-              <span className="font-extrabold text-[22px] text-brand leading-none">{initials}</span>
-            </div>
-            <div className="font-bold text-base text-slate-800 dark:text-slate-100 leading-6 mb-0.5">{profile?.displayName ?? user.name}</div>
-            <div className="text-xs text-slate-400 dark:text-slate-500 leading-[18px] mb-3">@{profile?.username ?? user.username}</div>
-            {profile?.belief && (
-              <div className="inline-flex items-center bg-brand-tint rounded-xl px-2.5 py-0.5 mb-2">
-                <span className="font-semibold text-[11px] text-brand leading-[16.5px] whitespace-nowrap">{profile.belief}</span>
-              </div>
-            )}
-            {profile?.createdAt && (
-              <div className="text-[11px] text-slate-300 dark:text-slate-600 leading-[16.5px]">
-                Membro desde {formatMemberSince(profile.createdAt)}
-              </div>
-            )}
-          </div>
+					{/* COMMENTS */}
+					{tab === "comments" && (
+						<div className="flex flex-col gap-5">
+							<h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0">
+								Meus Comentários
+							</h2>
+							<SearchBar
+								value={commentSearch}
+								onChange={setCommentSearch}
+								placeholder="Buscar nos meus comentários…"
+							/>
+							{loading && comments.length === 0 ? (
+								<Loading />
+							) : filteredComments.length === 0 ? (
+								<div className="text-center text-slate-400 dark:text-slate-500 py-10 text-sm">
+									{commentSearch
+										? `Nenhum resultado para "${commentSearch}".`
+										: "Nenhum comentário ainda."}
+								</div>
+							) : (
+								<div className="flex flex-col gap-2.5">
+									{filteredComments.map((c) => (
+										<ProfileCommentCard
+											key={c._id}
+											comment={c}
+											onEdit={setEditingComment}
+											onDelete={handleDelete}
+										/>
+									))}
+								</div>
+							)}
+						</div>
+					)}
 
-          {/* Navigation — icon-only tabs on mobile, full sidebar on md+ */}
-          <nav
-            aria-label="Seções do perfil"
-            className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl py-[6.667px] px-[8.667px] flex flex-row md:flex-col gap-0.5 justify-around md:justify-start"
-          >
-            {NAV_ITEMS.map(({ id, label, icon }) => {
-              const active = tab === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setTab(id)}
-                  aria-label={label}
-                  title={label}
-                  aria-current={active ? "page" : undefined}
-                  className={`flex items-center justify-center md:justify-start gap-0 md:gap-2.5 h-[37.5px] w-[37.5px] md:h-[37.5px] md:w-full md:pl-3 md:pr-3 rounded-md border-none cursor-pointer transition-colors ${
-                    active
-                      ? "bg-brand-wash text-brand"
-                      : "bg-transparent text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800"
-                  }`}
-                >
-                  <span className="flex items-center shrink-0">{icon}</span>
-                  <span
-                    className={`hidden md:inline text-[13px] leading-[19.5px] whitespace-nowrap ${
-                      active ? "font-semibold" : "font-normal"
-                    }`}
-                  >
-                    {label}
-                  </span>
-                </button>
-              );
-            })}
-            {user.moderator && (
-              <Link
-                href="/admin/moderation"
-                aria-label="Moderação"
-                title="Moderação"
-                className="flex items-center justify-center md:justify-start gap-0 md:gap-2.5 h-[37.5px] w-[37.5px] md:h-[37.5px] md:w-full md:pl-3 md:pr-3 rounded-md no-underline transition-colors text-amber-700 dark:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/20"
-              >
-                <span className="flex items-center shrink-0">
-                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-                  </svg>
-                </span>
-                <span className="hidden md:inline text-[13px] leading-[19.5px] whitespace-nowrap font-semibold">
-                  Moderação
-                </span>
-              </Link>
-            )}
-          </nav>
-        </aside>
+					{/* FAVORITES */}
+					{tab === "favorites" && (
+						<div className="flex flex-col gap-5">
+							<h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0">
+								Favoritos
+							</h2>
 
-        {/* ── Main content ── */}
-        <main id="main-content" className="flex-1 min-w-0">
+							{/* Search bar */}
+							<SearchBar
+								value={favSearch}
+								onChange={setFavSearch}
+								placeholder="Buscar nos favoritos…"
+							/>
 
-          {/* OVERVIEW */}
-          {tab === "overview" && (
-            <div>
-              <div className="mb-6">
-                <h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0 mb-1">
-                  Olá, {user.name.split(" ")[0]} 👋
-                </h2>
-                <p className="text-[13px] text-slate-400 dark:text-slate-500 m-0">
-                  Aqui está um resumo da sua atividade no BibleComment.
-                </p>
-              </div>
-              {profile ? (
-                <>
-                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-3">
-                    <StatCard label="Comentários" value={profile.commentsCount} max={0} color="#137ddb" />
-                    <StatCard label="Livros comentados" value={profile.booksCount} max={66} color="#7c3aed" />
-                    <StatCard label="Capítulos comentados" value={profile.chaptersCount} max={1189} color="#059669" />
-                  </div>
-                  <div className="grid grid-cols-2 gap-3 mb-7" data-testid="profile-social-stats">
-                    <Link
-                      href={`/u/${user.username}/followers`}
-                      data-testid="profile-followers-link"
-                      className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4 hover:border-brand transition no-underline"
-                    >
-                      <div className="text-[11px] uppercase tracking-wider font-semibold text-slate-400 dark:text-slate-500">
-                        Seguidores
-                      </div>
-                      <div className="text-2xl font-bold text-slate-800 dark:text-slate-100 mt-1">
-                        {profile.followersCount ?? 0}
-                      </div>
-                      <div className="text-[11px] text-brand mt-1">Ver lista →</div>
-                    </Link>
-                    <Link
-                      href={`/u/${user.username}/following`}
-                      data-testid="profile-following-link"
-                      className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4 hover:border-brand transition no-underline"
-                    >
-                      <div className="text-[11px] uppercase tracking-wider font-semibold text-slate-400 dark:text-slate-500">
-                        Seguindo
-                      </div>
-                      <div className="text-2xl font-bold text-slate-800 dark:text-slate-100 mt-1">
-                        {profile.followingCount ?? 0}
-                      </div>
-                      <div className="text-[11px] text-brand mt-1">Ver lista →</div>
-                    </Link>
-                  </div>
-                </>
-              ) : (
-                <Loading />
-              )}
-              {comments.length > 0 && (
-                <div>
-                  <div className="flex items-center justify-between mb-3">
-                    <h3 className="font-semibold text-xs text-slate-400 dark:text-slate-500 m-0 uppercase tracking-wider">
-                      Comentários recentes
-                    </h3>
-                    <button
-                      type="button"
-                      onClick={() => setTab("comments")}
-                      className="text-xs text-brand bg-transparent border-none cursor-pointer hover:underline"
-                    >
-                      Ver todos
-                    </button>
-                  </div>
-                  <div className="flex flex-col gap-2.5">
-                    {comments.slice(0, 3).map(c => <ProfileCommentCard key={c._id} comment={c} />)}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
+							{/* Type filter pills */}
+							<div className="flex gap-2 flex-wrap">
+								{TYPE_FILTERS.map((f) => {
+									const active = favTypeFilter === f;
+									return (
+										<button
+											key={f}
+											type="button"
+											onClick={() => setFavTypeFilter(f)}
+											className={`h-7 px-3.5 rounded-[20px] text-xs leading-[18px] transition-colors duration-150 ${
+												active
+													? "bg-brand text-white font-semibold"
+													: "bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 font-normal"
+											}`}
+										>
+											{f}
+										</button>
+									);
+								})}
+							</div>
 
-          {/* COMMENTS */}
-          {tab === "comments" && (
-            <div className="flex flex-col gap-5">
-              <h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0">
-                Meus Comentários
-              </h2>
-              <SearchBar value={commentSearch} onChange={setCommentSearch} placeholder="Buscar nos meus comentários…" />
-              {loading && comments.length === 0 ? (
-                <Loading />
-              ) : filteredComments.length === 0 ? (
-                <div className="text-center text-slate-400 dark:text-slate-500 py-10 text-sm">
-                  {commentSearch ? `Nenhum resultado para "${commentSearch}".` : "Nenhum comentário ainda."}
-                </div>
-              ) : (
-                <div className="flex flex-col gap-2.5">
-                  {filteredComments.map(c => (
-                    <ProfileCommentCard key={c._id} comment={c} onEdit={setEditingComment} onDelete={handleDelete} />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+							{/* Autores Favoritos card */}
+							{favoriteAuthors.length > 0 && (
+								<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-5 py-4">
+									<div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 mb-3">
+										Autores Favoritos
+									</div>
+									<div className="flex gap-2.5 flex-wrap">
+										{favoriteAuthors.map(({ username, count }) => {
+											const ini = getInitials(username);
+											return (
+												<div
+													key={username}
+													className="flex items-center gap-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg px-3 py-1.5 h-[46.333px]"
+												>
+													{/* Avatar */}
+													<div className="w-7 h-7 rounded-full bg-brand/10 flex items-center justify-center flex-shrink-0">
+														<span className="font-bold text-[11px] text-brand leading-[16.5px]">
+															{ini}
+														</span>
+													</div>
+													{/* Username + like count */}
+													<div className="flex flex-col">
+														<Link
+															href={`/u/${username}`}
+															className="font-semibold text-xs text-slate-800 dark:text-slate-100 whitespace-nowrap hover:underline"
+														>
+															@{username}
+														</Link>
+														<span className="text-[10px] text-slate-400 dark:text-slate-500">
+															{count} curtido{count !== 1 ? "s" : ""}
+														</span>
+													</div>
+												</div>
+											);
+										})}
+									</div>
+								</div>
+							)}
 
-          {/* FAVORITES */}
-          {tab === "favorites" && (
-            <div className="flex flex-col gap-5">
-              <h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0">
-                Favoritos
-              </h2>
+							{/* Favorite comment cards */}
+							{loading && favorites.length === 0 ? (
+								<Loading />
+							) : filteredFavorites.length === 0 ? (
+								<div className="text-center text-slate-400 dark:text-slate-500 py-10 text-sm">
+									{favSearch || favTypeFilter !== "Todos"
+										? "Nenhum favorito encontrado com esses filtros."
+										: "Nenhum favorito ainda."}
+								</div>
+							) : (
+								<div className="flex flex-col gap-2.5">
+									{filteredFavorites.map((c) => (
+										<FavoriteCard key={c._id} comment={c} />
+									))}
+								</div>
+							)}
+						</div>
+					)}
 
-              {/* Search bar */}
-              <SearchBar value={favSearch} onChange={setFavSearch} placeholder="Buscar nos favoritos…" />
+					{/* BADGES */}
+					{tab === "badges" && <BadgesTab />}
 
-              {/* Type filter pills */}
-              <div className="flex gap-2 flex-wrap">
-                {TYPE_FILTERS.map(f => {
-                  const active = favTypeFilter === f;
-                  return (
-                    <button
-                      key={f}
-                      type="button"
-                      onClick={() => setFavTypeFilter(f)}
-                      className={`h-7 px-3.5 rounded-[20px] text-xs leading-[18px] transition-colors duration-150 ${
-                        active
-                          ? "bg-brand text-white font-semibold"
-                          : "bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 font-normal"
-                      }`}
-                    >
-                      {f}
-                    </button>
-                  );
-                })}
-              </div>
+					{/* CONFIG */}
+					{tab === "config" && (
+						<div className="flex flex-col gap-5">
+							{/* Title */}
+							<h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0">
+								Configurações &amp; Privacidade
+							</h2>
 
-              {/* Autores Favoritos card */}
-              {favoriteAuthors.length > 0 && (
-                <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-5 py-4">
-                  <div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 mb-3">
-                    Autores Favoritos
-                  </div>
-                  <div className="flex gap-2.5 flex-wrap">
-                    {favoriteAuthors.map(({ username, count }) => {
-                      const ini = getInitials(username);
-                      return (
-                        <div
-                          key={username}
-                          className="flex items-center gap-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg px-3 py-1.5 h-[46.333px]"
-                        >
-                          {/* Avatar */}
-                          <div className="w-7 h-7 rounded-full bg-brand/10 flex items-center justify-center flex-shrink-0">
-                            <span className="font-bold text-[11px] text-brand leading-[16.5px]">{ini}</span>
-                          </div>
-                          {/* Username + like count */}
-                          <div className="flex flex-col">
-                            <Link
-                              href={`/u/${username}`}
-                              className="font-semibold text-xs text-slate-800 dark:text-slate-100 whitespace-nowrap hover:underline"
-                            >
-                              @{username}
-                            </Link>
-                            <span className="text-[10px] text-slate-400 dark:text-slate-500">{count} curtido{count !== 1 ? "s" : ""}</span>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
+							{/* ── Card: Identidade (display name + slug) ── */}
+							{profile && (
+								<IdentityCard
+									initialDisplayName={
+										profile.displayName ?? user.name ?? user.username
+									}
+									initialUsername={profile.username}
+									onUpdated={(next) => {
+										setProfile((p) => (p ? { ...p, ...next } : p));
+									}}
+								/>
+							)}
 
-              {/* Favorite comment cards */}
-              {loading && favorites.length === 0 ? (
-                <Loading />
-              ) : filteredFavorites.length === 0 ? (
-                <div className="text-center text-slate-400 dark:text-slate-500 py-10 text-sm">
-                  {favSearch || favTypeFilter !== "Todos"
-                    ? "Nenhum favorito encontrado com esses filtros."
-                    : "Nenhum favorito ainda."}
-                </div>
-              ) : (
-                <div className="flex flex-col gap-2.5">
-                  {filteredFavorites.map(c => <FavoriteCard key={c._id} comment={c} />)}
-                </div>
-              )}
-            </div>
-          )}
+							{/* ── Card 1: Informações da Conta ── */}
+							<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
+								<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-5">
+									Informações da Conta
+								</div>
+								<div className="flex flex-col gap-1.5 mb-5">
+									<label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
+										Crença / Denominação
+									</label>
+									<select
+										value={belief}
+										onChange={(e) => setBelief(e.target.value)}
+										className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 rounded-lg px-3 text-[13px] text-slate-800 dark:text-slate-100 bg-white dark:bg-slate-900 outline-none cursor-pointer"
+									>
+										{beliefs.map((b) => (
+											<option key={b} value={b}>
+												{b}
+											</option>
+										))}
+									</select>
+								</div>
+								<button
+									onClick={handleUpdateAccount}
+									className="h-[35.5px] px-5 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer"
+								>
+									Salvar alterações
+								</button>
+							</div>
 
-          {/* BADGES */}
-          {tab === "badges" && <BadgesTab />}
+							{/* ── Card 2: Privacidade ── */}
+							<div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 py-5">
+								<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-4">
+									Privacidade
+								</div>
 
-          {/* CONFIG */}
-          {tab === "config" && (
-            <div className="flex flex-col gap-5">
-              {/* Title */}
-              <h2 className="font-bold text-xl text-slate-800 dark:text-slate-100 m-0">
-                Configurações &amp; Privacidade
-              </h2>
+								{/* Toggle 1 */}
+								<div
+									className="flex items-start gap-3.5 pb-4"
+									data-testid="show-belief-toggle"
+								>
+									<PrivacyToggle
+										checked={showReligion}
+										onChange={setShowReligion}
+									/>
+									<div>
+										<div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 leading-[19.5px]">
+											Mostrar minha religião no perfil público
+										</div>
+										<div className="text-xs text-slate-400 dark:text-slate-500 leading-[18px] mt-0.5">
+											Outros usuários poderão ver sua denominação na sua página
+											de perfil.
+										</div>
+									</div>
+								</div>
 
-              {/* ── Card: Identidade (display name + slug) ── */}
-              {profile && (
-                <IdentityCard
-                  initialDisplayName={profile.displayName ?? user.name ?? user.username}
-                  initialUsername={profile.username}
-                  onUpdated={(next) => {
-                    setProfile((p) => p ? { ...p, ...next } : p);
-                  }}
-                />
-              )}
+								{/* Divider */}
+								<div className="h-px bg-slate-50 dark:bg-slate-800 mb-4" />
 
-              {/* ── Card 1: Informações da Conta ── */}
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 pt-5 pb-6">
-                <div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-5">
-                  Informações da Conta
-                </div>
-                <div className="flex flex-col gap-1.5 mb-5">
-                  <label className="font-semibold text-[13px] text-slate-800 dark:text-slate-100">
-                    Crença / Denominação
-                  </label>
-                  <select
-                    value={belief}
-                    onChange={e => setBelief(e.target.value)}
-                    className="w-full h-[38.833px] border border-slate-200 dark:border-slate-700 rounded-lg px-3 text-[13px] text-slate-800 dark:text-slate-100 bg-white dark:bg-slate-900 outline-none cursor-pointer"
-                  >
-                    {beliefs.map(b => <option key={b} value={b}>{b}</option>)}
-                  </select>
-                </div>
-                <button
-                  onClick={handleUpdateAccount}
-                  className="h-[35.5px] px-5 bg-brand text-white rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer"
-                >
-                  Salvar alterações
-                </button>
-              </div>
+								{/* Toggle 2 */}
+								<div className="flex items-start gap-3.5">
+									<PrivacyToggle
+										checked={showHistory}
+										onChange={setShowHistory}
+									/>
+									<div>
+										<div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 leading-[19.5px]">
+											Permitir que outros vejam meu histórico de comentários
+										</div>
+										<div className="text-xs text-slate-400 dark:text-slate-500 leading-[18px] mt-0.5">
+											Se desativado, seus comentários ficam anônimos para outros
+											leitores.
+										</div>
+									</div>
+								</div>
+							</div>
 
-              {/* ── Card 2: Privacidade ── */}
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-6 py-5">
-                <div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-4">
-                  Privacidade
-                </div>
+							{/* ── Card: Trocar senha ── */}
+							<ChangePasswordCard />
 
-                {/* Toggle 1 */}
-                <div className="flex items-start gap-3.5 pb-4" data-testid="show-belief-toggle">
-                  <PrivacyToggle checked={showReligion} onChange={setShowReligion} />
-                  <div>
-                    <div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 leading-[19.5px]">
-                      Mostrar minha religião no perfil público
-                    </div>
-                    <div className="text-xs text-slate-400 dark:text-slate-500 leading-[18px] mt-0.5">
-                      Outros usuários poderão ver sua denominação na sua página de perfil.
-                    </div>
-                  </div>
-                </div>
+							{/* ── Card: Tutorial guiado ── */}
+							<TutorialResetCard />
 
-                {/* Divider */}
-                <div className="h-px bg-slate-50 dark:bg-slate-800 mb-4" />
+							{/* ── Card: Meus dados (LGPD Art. 18 - portabilidade) ── */}
+							<MyDataCard onCommentsImported={loadComments} />
 
-                {/* Toggle 2 */}
-                <div className="flex items-start gap-3.5">
-                  <PrivacyToggle checked={showHistory} onChange={setShowHistory} />
-                  <div>
-                    <div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 leading-[19.5px]">
-                      Permitir que outros vejam meu histórico de comentários
-                    </div>
-                    <div className="text-xs text-slate-400 dark:text-slate-500 leading-[18px] mt-0.5">
-                      Se desativado, seus comentários ficam anônimos para outros leitores.
-                    </div>
-                  </div>
-                </div>
-              </div>
+							{/* ── Card 3: Zona de Perigo ── */}
+							<div className="bg-white dark:bg-slate-900 border border-red-200 dark:border-red-900/40 rounded-xl px-6 pt-5 pb-6">
+								<div className="font-bold text-sm text-red-700 dark:text-red-300 mb-3">
+									Zona de Perigo
+								</div>
+								<p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-5 mt-0">
+									A exclusão da conta é permanente e irrecuperável. Seu cadastro
+									é apagado e seus comentários e discussões ficam anônimos sob
+									&ldquo;[usuário removido]&rdquo;, preservando o contexto das
+									conversas para outros leitores.
+									{comments.length > 0 &&
+										` Total de comentários a serem anonimizados: ${comments.length}.`}
+								</p>
+								<button
+									onClick={handleDeleteAccount}
+									className="h-[36.167px] px-5 bg-transparent text-red-600 dark:text-red-400 border-[1.333px] border-red-600 dark:border-red-400 rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer"
+								>
+									Excluir minha conta
+								</button>
+							</div>
+						</div>
+					)}
+				</main>
+			</div>
 
-              {/* ── Card: Trocar senha ── */}
-              <ChangePasswordCard />
-
-              {/* ── Card: Tutorial guiado ── */}
-              <TutorialResetCard />
-
-              {/* ── Card: Meus dados (LGPD Art. 18 - portabilidade) ── */}
-              <MyDataCard onCommentsImported={loadComments} />
-
-              {/* ── Card 3: Zona de Perigo ── */}
-              <div className="bg-white dark:bg-slate-900 border border-red-200 dark:border-red-900/40 rounded-xl px-6 pt-5 pb-6">
-                <div className="font-bold text-sm text-red-700 dark:text-red-300 mb-3">
-                  Zona de Perigo
-                </div>
-                <p className="text-[13px] text-slate-500 dark:text-slate-400 leading-[19.5px] mb-5 mt-0">
-                  A exclusão da conta é permanente e irrecuperável. Seu cadastro
-                  é apagado e seus comentários e discussões ficam anônimos sob
-                  &ldquo;[usuário removido]&rdquo;, preservando o contexto das
-                  conversas para outros leitores.
-                  {comments.length > 0 && ` Total de comentários a serem anonimizados: ${comments.length}.`}
-                </p>
-                <button
-                  onClick={handleDeleteAccount}
-                  className="h-[36.167px] px-5 bg-transparent text-red-600 dark:text-red-400 border-[1.333px] border-red-600 dark:border-red-400 rounded-[7px] text-[13px] font-semibold whitespace-nowrap cursor-pointer"
-                >
-                  Excluir minha conta
-                </button>
-              </div>
-            </div>
-          )}
-        </main>
-      </div>
-
-      {/* Edit comment modal */}
-      {editingComment && (
-        <Modal show={!!editingComment} onClose={() => setEditingComment(null)}>
-          <NewCommentForm
-            post={false}
-            title="Editar comentário"
-            onClose={() => setEditingComment(null)}
-            onSaved={updated => {
-              setComments(prev => prev.map(c => c._id === updated._id ? updated : c));
-              setEditingComment(null);
-            }}
-            commentId={editingComment._id}
-            initialText={editingComment.text}
-          />
-        </Modal>
-      )}
-    </div>
-  );
+			{/* Edit comment modal */}
+			{editingComment && (
+				<Modal show={!!editingComment} onClose={() => setEditingComment(null)}>
+					<NewCommentForm
+						post={false}
+						title="Editar comentário"
+						onClose={() => setEditingComment(null)}
+						onSaved={(updated) => {
+							setComments((prev) =>
+								prev.map((c) => (c._id === updated._id ? updated : c)),
+							);
+							setEditingComment(null);
+						}}
+						commentId={editingComment._id}
+						initialText={editingComment.text}
+					/>
+				</Modal>
+			)}
+		</div>
+	);
 }

--- a/nextjs/src/app/u/[username]/PublicProfileClient.tsx
+++ b/nextjs/src/app/u/[username]/PublicProfileClient.tsx
@@ -11,384 +11,398 @@ import { followService } from "@/services/follow";
 import { useNotification } from "@/contexts/NotificationContext";
 
 interface ViewerSession {
-  name: string;
-  username: string;
-  email?: string | null;
-  moderator?: boolean;
+	name: string;
+	username: string;
+	email?: string | null;
+	moderator?: boolean;
 }
 
 export interface PublicProfileUser {
-  username: string;
-  displayName?: string;
-  badges: string[];
-  belief?: string;
-  createdAt: string;
+	username: string;
+	displayName?: string;
+	badges: string[];
+	belief?: string;
+	createdAt: string;
 }
 
 export interface PublicProfileComment {
-  _id?: string;
-  bookReference: string;
-  text: string;
-  tags: string[];
-  createdAt: string | null;
+	_id?: string;
+	bookReference: string;
+	text: string;
+	tags: string[];
+	createdAt: string | null;
 }
 
 export interface PublicProfileFollowState {
-  followers: number;
-  following: number;
-  isFollowing: boolean;
+	followers: number;
+	following: number;
+	isFollowing: boolean;
 }
 
 interface Props {
-  user: PublicProfileUser;
-  initialComments: PublicProfileComment[];
-  initialHasMore: boolean;
-  /** Logged-in viewer's session, or null for anonymous browsing. */
-  viewer: ViewerSession | null;
-  initialFollowState: PublicProfileFollowState;
+	user: PublicProfileUser;
+	initialComments: PublicProfileComment[];
+	initialHasMore: boolean;
+	/** Logged-in viewer's session, or null for anonymous browsing. */
+	viewer: ViewerSession | null;
+	initialFollowState: PublicProfileFollowState;
 }
 
 const PAGE_SIZE = 20;
 
 function memberSince(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return "";
-  return d.toLocaleDateString("pt-BR", { month: "long", year: "numeric" });
+	const d = new Date(iso);
+	if (isNaN(d.getTime())) return "";
+	return d.toLocaleDateString("pt-BR", { month: "long", year: "numeric" });
 }
 
 function dateFormat(iso: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return "";
-  return d.toLocaleDateString("pt-BR", { day: "2-digit", month: "short", year: "numeric" });
+	if (!iso) return "";
+	const d = new Date(iso);
+	if (isNaN(d.getTime())) return "";
+	return d.toLocaleDateString("pt-BR", {
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+	});
 }
 
 function getInitials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+	const parts = name.trim().split(/\s+/);
+	if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+	return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
 type Tab = "badges" | "comments";
 
 export default function PublicProfileClient({
-  user,
-  initialComments,
-  initialHasMore,
-  viewer,
-  initialFollowState,
+	user,
+	initialComments,
+	initialHasMore,
+	viewer,
+	initialFollowState,
 }: Props) {
-  const router = useRouter();
-  const { handleNotification } = useNotification();
-  const [tab, setTab] = useState<Tab>("badges");
-  const [comments, setComments] = useState<PublicProfileComment[]>(initialComments);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(initialHasMore);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [followState, setFollowState] = useState<PublicProfileFollowState>(initialFollowState);
-  const [followBusy, setFollowBusy] = useState(false);
+	const router = useRouter();
+	const { handleNotification } = useNotification();
+	const [tab, setTab] = useState<Tab>("badges");
+	const [comments, setComments] =
+		useState<PublicProfileComment[]>(initialComments);
+	const [page, setPage] = useState(1);
+	const [hasMore, setHasMore] = useState(initialHasMore);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [followState, setFollowState] =
+		useState<PublicProfileFollowState>(initialFollowState);
+	const [followBusy, setFollowBusy] = useState(false);
 
-  // Deep-link friendly back behavior: prefer router.back() (so users return
-  // to wherever they came from — chapter page, feed, etc.). When there is
-  // no history (direct landing on /u/foo), fall back to /home.
-  function handleBack() {
-    if (typeof window !== "undefined" && window.history.length > 1) {
-      router.back();
-    } else {
-      router.push("/home");
-    }
-  }
+	// Deep-link friendly back behavior: prefer router.back() (so users return
+	// to wherever they came from — chapter page, feed, etc.). When there is
+	// no history (direct landing on /u/foo), fall back to /home.
+	function handleBack() {
+		if (typeof window !== "undefined" && window.history.length > 1) {
+			router.back();
+		} else {
+			router.push("/home");
+		}
+	}
 
-  const display = user.displayName ?? user.username;
-  const initials = getInitials(display);
+	const display = user.displayName ?? user.username;
+	const initials = getInitials(display);
 
-  const canFollow = !!viewer && viewer.username !== user.username;
+	const canFollow = !!viewer && viewer.username !== user.username;
 
-  async function handleToggleFollow() {
-    if (!canFollow || followBusy) return;
-    setFollowBusy(true);
-    const wasFollowing = followState.isFollowing;
-    // Optimistic update — UI snaps immediately. Rolls back on failure.
-    setFollowState((s) => ({
-      ...s,
-      isFollowing: !wasFollowing,
-      followers: s.followers + (wasFollowing ? -1 : 1),
-    }));
-    try {
-      if (wasFollowing) await followService.unfollow(user.username);
-      else await followService.follow(user.username);
-    } catch {
-      setFollowState((s) => ({
-        ...s,
-        isFollowing: wasFollowing,
-        followers: s.followers + (wasFollowing ? 1 : -1),
-      }));
-      handleNotification(
-        "error",
-        wasFollowing ? "Erro ao deixar de seguir." : "Erro ao seguir usuário.",
-      );
-    } finally {
-      setFollowBusy(false);
-    }
-  }
+	async function handleToggleFollow() {
+		if (!canFollow || followBusy) return;
+		setFollowBusy(true);
+		const wasFollowing = followState.isFollowing;
+		// Optimistic update — UI snaps immediately. Rolls back on failure.
+		setFollowState((s) => ({
+			...s,
+			isFollowing: !wasFollowing,
+			followers: s.followers + (wasFollowing ? -1 : 1),
+		}));
+		try {
+			if (wasFollowing) await followService.unfollow(user.username);
+			else await followService.follow(user.username);
+		} catch {
+			setFollowState((s) => ({
+				...s,
+				isFollowing: wasFollowing,
+				followers: s.followers + (wasFollowing ? 1 : -1),
+			}));
+			handleNotification(
+				"error",
+				wasFollowing ? "Erro ao deixar de seguir." : "Erro ao seguir usuário.",
+			);
+		} finally {
+			setFollowBusy(false);
+		}
+	}
 
-  const earnedBadges = user.badges
-    .map((id) => getBadge(id))
-    .filter((b): b is NonNullable<typeof b> => Boolean(b));
+	const earnedBadges = user.badges
+		.map((id) => getBadge(id))
+		.filter((b): b is NonNullable<typeof b> => Boolean(b));
 
-  async function loadMore() {
-    if (loading || !hasMore) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const next = page + 1;
-      const res = await fetch(`/api/users/${user.username}/comments?page=${next}`);
-      if (!res.ok) throw new Error("fetch failed");
-      const json = (await res.json()) as {
-        comments: Array<{
-          _id?: string;
-          bookReference: string;
-          text: string;
-          tags: string[];
-          createdAt?: string | null;
-        }>;
-      };
-      const more: PublicProfileComment[] = json.comments.map((c) => ({
-        _id: c._id,
-        bookReference: c.bookReference,
-        text: c.text,
-        tags: c.tags,
-        createdAt: c.createdAt ?? null,
-      }));
-      setComments((prev) => [...prev, ...more]);
-      setPage(next);
-      if (more.length < PAGE_SIZE) setHasMore(false);
-    } catch {
-      setError("Erro ao carregar mais comentários.");
-    } finally {
-      setLoading(false);
-    }
-  }
+	async function loadMore() {
+		if (loading || !hasMore) return;
+		setLoading(true);
+		setError(null);
+		try {
+			const next = page + 1;
+			const res = await fetch(
+				`/api/users/${user.username}/comments?page=${next}`,
+			);
+			if (!res.ok) throw new Error("fetch failed");
+			const json = (await res.json()) as {
+				comments: Array<{
+					_id?: string;
+					bookReference: string;
+					text: string;
+					tags: string[];
+					createdAt?: string | null;
+				}>;
+			};
+			const more: PublicProfileComment[] = json.comments.map((c) => ({
+				_id: c._id,
+				bookReference: c.bookReference,
+				text: c.text,
+				tags: c.tags,
+				createdAt: c.createdAt ?? null,
+			}));
+			setComments((prev) => [...prev, ...more]);
+			setPage(next);
+			if (more.length < PAGE_SIZE) setHasMore(false);
+		} catch {
+			setError("Erro ao carregar mais comentários.");
+		} finally {
+			setLoading(false);
+		}
+	}
 
-  const isMe = viewer?.username === user.username;
+	const isMe = viewer?.username === user.username;
 
-  return (
-    <div className="min-h-screen bg-gray-50 dark:bg-slate-950">
-      <AppHeader user={viewer} loginCallbackUrl={`/u/${user.username}`} />
-      <main id="main-content" className="max-w-3xl mx-auto px-4 py-6">
-        <button
-          type="button"
-          onClick={handleBack}
-          data-testid="public-profile-back"
-          className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-brand dark:hover:text-brand mb-4 -ml-1 px-1 py-1 rounded transition"
-          aria-label="Voltar"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <polyline points="15 18 9 12 15 6" />
-          </svg>
-          Voltar
-        </button>
+	return (
+		<div className="min-h-screen bg-gray-50 dark:bg-slate-950">
+			<AppHeader user={viewer} loginCallbackUrl={`/u/${user.username}`} />
+			<main id="main-content" className="max-w-3xl mx-auto px-4 py-6">
+				<button
+					type="button"
+					onClick={handleBack}
+					data-testid="public-profile-back"
+					className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-brand dark:hover:text-brand mb-4 -ml-1 px-1 py-1 rounded transition"
+					aria-label="Voltar"
+				>
+					<svg
+						width="18"
+						height="18"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true"
+					>
+						<polyline points="15 18 9 12 15 6" />
+					</svg>
+					Voltar
+				</button>
 
-        <header
-          data-testid="public-profile-header"
-          className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 flex items-center gap-4 mb-6"
-        >
-          <div
-            aria-hidden="true"
-            className="flex-none w-16 h-16 rounded-full bg-brand-tint text-brand flex items-center justify-center font-bold text-xl"
-          >
-            {initials}
-          </div>
-          <div className="min-w-0 flex-1">
-            <h1
-              data-testid="public-profile-displayname"
-              className="font-bold text-xl text-slate-800 dark:text-slate-100 truncate"
-            >
-              {display}
-            </h1>
-            <p
-              data-testid="public-profile-username"
-              className="text-sm text-slate-500 dark:text-slate-400"
-            >
-              @{user.username}
-            </p>
-            {user.belief && (
-              <p
-                data-testid="public-profile-belief"
-                className="text-xs mt-2 inline-flex items-center bg-brand-tint text-brand rounded-full px-2.5 py-0.5 font-semibold"
-              >
-                {user.belief}
-              </p>
-            )}
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-slate-500 dark:text-slate-400">
-              <Link
-                href={`/u/${user.username}/followers`}
-                data-testid="public-profile-followers"
-                className="hover:text-brand transition"
-              >
-                <strong className="text-slate-800 dark:text-slate-100">{followState.followers}</strong>{" "}
-                {followState.followers === 1 ? "seguidor" : "seguidores"}
-              </Link>
-              <Link
-                href={`/u/${user.username}/following`}
-                data-testid="public-profile-following"
-                className="hover:text-brand transition"
-              >
-                <strong className="text-slate-800 dark:text-slate-100">{followState.following}</strong>{" "}
-                seguindo
-              </Link>
-              <span className="text-slate-400 dark:text-slate-500">
-                Membro desde {memberSince(user.createdAt)}
-              </span>
-            </div>
-          </div>
-          <div className="flex-none flex flex-col gap-2 items-end">
-            {isMe && (
-              <Link
-                href="/profile"
-                className="text-xs font-semibold px-3 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition"
-              >
-                Editar perfil
-              </Link>
-            )}
-            {canFollow && (
-              <button
-                type="button"
-                onClick={handleToggleFollow}
-                disabled={followBusy}
-                data-testid="public-profile-follow-button"
-                data-following={followState.isFollowing ? "true" : "false"}
-                className={`text-xs font-semibold px-3 py-1.5 rounded-md transition disabled:opacity-60 ${
-                  followState.isFollowing
-                    ? "border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-600 dark:hover:text-red-300 hover:border-red-200 dark:hover:border-red-900/60"
-                    : "bg-brand text-white hover:bg-brand/90"
-                }`}
-              >
-                {followState.isFollowing ? "Seguindo" : "Seguir"}
-              </button>
-            )}
-          </div>
-        </header>
+				<header
+					data-testid="public-profile-header"
+					className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 flex items-center gap-4 mb-6"
+				>
+					<div
+						aria-hidden="true"
+						className="flex-none w-16 h-16 rounded-full bg-brand-tint text-brand flex items-center justify-center font-bold text-xl"
+					>
+						{initials}
+					</div>
+					<div className="min-w-0 flex-1">
+						<h1
+							data-testid="public-profile-displayname"
+							className="font-bold text-xl text-slate-800 dark:text-slate-100 truncate"
+						>
+							{display}
+						</h1>
+						<p
+							data-testid="public-profile-username"
+							className="text-sm text-slate-500 dark:text-slate-400"
+						>
+							@{user.username}
+						</p>
+						{user.belief && (
+							<p
+								data-testid="public-profile-belief"
+								className="text-xs mt-2 inline-flex items-center bg-brand-tint text-brand rounded-full px-2.5 py-0.5 font-semibold"
+							>
+								{user.belief}
+							</p>
+						)}
+						<div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-slate-500 dark:text-slate-400">
+							<Link
+								href={`/u/${user.username}/followers`}
+								data-testid="public-profile-followers"
+								className="hover:text-brand transition"
+							>
+								<strong className="text-slate-800 dark:text-slate-100">
+									{followState.followers}
+								</strong>{" "}
+								{followState.followers === 1 ? "seguidor" : "seguidores"}
+							</Link>
+							<Link
+								href={`/u/${user.username}/following`}
+								data-testid="public-profile-following"
+								className="hover:text-brand transition"
+							>
+								<strong className="text-slate-800 dark:text-slate-100">
+									{followState.following}
+								</strong>{" "}
+								seguindo
+							</Link>
+							<span className="text-slate-400 dark:text-slate-500">
+								Membro desde {memberSince(user.createdAt)}
+							</span>
+						</div>
+					</div>
+					<div className="flex-none flex flex-col gap-2 items-end">
+						{isMe && (
+							<Link
+								href="/profile"
+								className="text-xs font-semibold px-3 py-1.5 rounded-md border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition"
+							>
+								Editar perfil
+							</Link>
+						)}
+						{canFollow && (
+							<button
+								type="button"
+								onClick={handleToggleFollow}
+								disabled={followBusy}
+								data-testid="public-profile-follow-button"
+								data-following={followState.isFollowing ? "true" : "false"}
+								className={`text-xs font-semibold px-3 py-1.5 rounded-md transition disabled:opacity-60 ${
+									followState.isFollowing
+										? "border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-600 dark:hover:text-red-300 hover:border-red-200 dark:hover:border-red-900/60"
+										: "bg-brand text-white hover:bg-brand/90"
+								}`}
+							>
+								{followState.isFollowing ? "Seguindo" : "Seguir"}
+							</button>
+						)}
+					</div>
+				</header>
 
-        <nav
-          role="tablist"
-          aria-label="Seções do perfil"
-          className="flex gap-2 border-b border-slate-200 dark:border-slate-700 mb-4"
-        >
-          <button
-            type="button"
-            role="tab"
-            data-testid="public-profile-tab-badges"
-            aria-selected={tab === "badges"}
-            onClick={() => setTab("badges")}
-            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition ${
-              tab === "badges"
-                ? "border-brand text-brand"
-                : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
-            }`}
-          >
-            Conquistas ({earnedBadges.length})
-          </button>
-          <button
-            type="button"
-            role="tab"
-            data-testid="public-profile-tab-comments"
-            aria-selected={tab === "comments"}
-            onClick={() => setTab("comments")}
-            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition ${
-              tab === "comments"
-                ? "border-brand text-brand"
-                : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
-            }`}
-          >
-            Comentários
-          </button>
-        </nav>
+				<nav
+					role="tablist"
+					aria-label="Seções do perfil"
+					className="flex gap-2 border-b border-slate-200 dark:border-slate-700 mb-4"
+				>
+					<button
+						type="button"
+						role="tab"
+						data-testid="public-profile-tab-badges"
+						aria-selected={tab === "badges"}
+						onClick={() => setTab("badges")}
+						className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition ${
+							tab === "badges"
+								? "border-brand text-brand"
+								: "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+						}`}
+					>
+						Conquistas ({earnedBadges.length})
+					</button>
+					<button
+						type="button"
+						role="tab"
+						data-testid="public-profile-tab-comments"
+						aria-selected={tab === "comments"}
+						onClick={() => setTab("comments")}
+						className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition ${
+							tab === "comments"
+								? "border-brand text-brand"
+								: "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+						}`}
+					>
+						Comentários
+					</button>
+				</nav>
 
-        {tab === "badges" &&
-          (earnedBadges.length === 0 ? (
-            <p
-              data-testid="public-profile-badges-empty"
-              className="text-center text-sm text-slate-400 dark:text-slate-500 py-10"
-            >
-              Nenhuma conquista desbloqueada ainda.
-            </p>
-          ) : (
-            <div
-              data-testid="public-profile-badges"
-              className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-            >
-              {earnedBadges.map((b) => (
-                <BadgeCard key={b.id} badge={b} earned current={1} target={1} />
-              ))}
-            </div>
-          ))}
+				{tab === "badges" &&
+					(earnedBadges.length === 0 ? (
+						<p
+							data-testid="public-profile-badges-empty"
+							className="text-center text-sm text-slate-400 dark:text-slate-500 py-10"
+						>
+							Nenhuma conquista desbloqueada ainda.
+						</p>
+					) : (
+						<div
+							data-testid="public-profile-badges"
+							className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+						>
+							{earnedBadges.map((b) => (
+								<BadgeCard key={b.id} badge={b} earned current={1} target={1} />
+							))}
+						</div>
+					))}
 
-        {tab === "comments" &&
-          (comments.length === 0 ? (
-            <p
-              data-testid="public-profile-comments-empty"
-              className="text-center text-sm text-slate-400 dark:text-slate-500 py-10"
-            >
-              Nenhum comentário publicado.
-            </p>
-          ) : (
-            <div data-testid="public-profile-comments" className="flex flex-col gap-3">
-              {comments.map((c) => (
-                <article
-                  key={c._id}
-                  data-testid="public-profile-comment-card"
-                  className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4"
-                >
-                  <div className="flex flex-wrap items-center gap-2 mb-2 text-xs">
-                    {c.bookReference && (
-                      <span className="inline-flex items-center bg-brand-tint rounded px-2 h-5 font-bold text-brand whitespace-nowrap">
-                        {c.bookReference}
-                      </span>
-                    )}
-                    <TagBadges tags={c.tags} />
-                    <span className="ml-auto text-slate-400 dark:text-slate-500">
-                      {dateFormat(c.createdAt)}
-                    </span>
-                  </div>
-                  <p className="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap">
-                    {c.text}
-                  </p>
-                </article>
-              ))}
-              {hasMore && (
-                <div className="flex justify-center mt-2">
-                  <button
-                    type="button"
-                    onClick={loadMore}
-                    disabled={loading}
-                    data-testid="public-profile-load-more"
-                    className="text-sm font-semibold px-4 py-2 rounded-md border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition disabled:opacity-50"
-                  >
-                    {loading ? "Carregando…" : "Carregar mais"}
-                  </button>
-                </div>
-              )}
-              {error && (
-                <p className="text-center text-sm text-red-600 dark:text-red-400 py-2">
-                  {error}
-                </p>
-              )}
-            </div>
-          ))}
-
-      </main>
-    </div>
-  );
+				{tab === "comments" &&
+					(comments.length === 0 ? (
+						<p
+							data-testid="public-profile-comments-empty"
+							className="text-center text-sm text-slate-400 dark:text-slate-500 py-10"
+						>
+							Nenhum comentário publicado.
+						</p>
+					) : (
+						<div
+							data-testid="public-profile-comments"
+							className="flex flex-col gap-3"
+						>
+							{comments.map((c) => (
+								<article
+									key={c._id}
+									data-testid="public-profile-comment-card"
+									className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4"
+								>
+									<div className="flex flex-wrap items-center gap-2 mb-2 text-xs">
+										{c.bookReference && (
+											<span className="inline-flex items-center bg-brand-tint rounded px-2 h-5 font-bold text-brand whitespace-nowrap">
+												{c.bookReference}
+											</span>
+										)}
+										<TagBadges tags={c.tags} />
+										<span className="ml-auto text-slate-400 dark:text-slate-500">
+											{dateFormat(c.createdAt)}
+										</span>
+									</div>
+									<p className="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap">
+										{c.text}
+									</p>
+								</article>
+							))}
+							{hasMore && (
+								<div className="flex justify-center mt-2">
+									<button
+										type="button"
+										onClick={loadMore}
+										disabled={loading}
+										data-testid="public-profile-load-more"
+										className="text-sm font-semibold px-4 py-2 rounded-md border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition disabled:opacity-50"
+									>
+										{loading ? "Carregando…" : "Carregar mais"}
+									</button>
+								</div>
+							)}
+							{error && (
+								<p className="text-center text-sm text-red-600 dark:text-red-400 py-2">
+									{error}
+								</p>
+							)}
+						</div>
+					))}
+			</main>
+		</div>
+	);
 }

--- a/nextjs/src/app/u/[username]/PublicProfileClient.tsx
+++ b/nextjs/src/app/u/[username]/PublicProfileClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { AppHeader } from "@/components/AppHeader";
+import { TagBadges } from "@/components/TagBadges";
 import { BadgeCard } from "@/app/profile/_components/BadgeCard";
 import { getBadge } from "@/lib/badges/catalog";
 import { followService } from "@/services/follow";
@@ -350,12 +351,13 @@ export default function PublicProfileClient({
                   data-testid="public-profile-comment-card"
                   className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-4"
                 >
-                  <div className="flex items-center gap-2 mb-2 text-xs">
+                  <div className="flex flex-wrap items-center gap-2 mb-2 text-xs">
                     {c.bookReference && (
                       <span className="inline-flex items-center bg-brand-tint rounded px-2 h-5 font-bold text-brand whitespace-nowrap">
                         {c.bookReference}
                       </span>
                     )}
+                    <TagBadges tags={c.tags} />
                     <span className="ml-auto text-slate-400 dark:text-slate-500">
                       {dateFormat(c.createdAt)}
                     </span>

--- a/nextjs/src/components/CommentShareCard.tsx
+++ b/nextjs/src/components/CommentShareCard.tsx
@@ -34,24 +34,39 @@ export function CommentShareCard({
 				fontFamily: "sans-serif",
 			}}
 		>
-			{/* Header: logo + wordmark */}
+			{/* Header: mirrors the in-app AppHeader exactly —
+			    logo + "BibleComment" title + "A Program for His Glory"
+			    subtitle, same colors/weights. */}
 			<div style={{ display: "flex", alignItems: "center", gap: 18 }}>
 				{/* eslint-disable-next-line @next/next/no-img-element */}
 				<img
 					src={logoDataUri}
 					alt=""
-					width={wide ? 52 : 64}
-					height={wide ? 52 : 64}
+					width={wide ? 60 : 76}
+					height={wide ? 60 : 76}
 				/>
-				<div
-					style={{
-						display: "flex",
-						fontSize: wide ? 30 : 36,
-						fontWeight: 700,
-						color: brand,
-					}}
-				>
-					Bible Comment
+				<div style={{ display: "flex", flexDirection: "column" }}>
+					<div
+						style={{
+							display: "flex",
+							fontSize: wide ? 32 : 40,
+							fontWeight: 700,
+							color: "#1e293b",
+							lineHeight: 1.2,
+						}}
+					>
+						BibleComment
+					</div>
+					<div
+						style={{
+							display: "flex",
+							fontSize: wide ? 18 : 22,
+							fontWeight: 300,
+							color: "#888888",
+						}}
+					>
+						A Program for His Glory
+					</div>
 				</div>
 			</div>
 

--- a/nextjs/src/components/CommentShareCard.tsx
+++ b/nextjs/src/components/CommentShareCard.tsx
@@ -1,0 +1,125 @@
+import { getTagMetas } from "@/lib/tag-meta";
+import type { CommentCardProps } from "@/lib/share-comment";
+
+/**
+ * Inline-styled card consumed by `next/og` ImageResponse (satori) — NO
+ * Tailwind, NO hooks, every multi-child node sets display:flex (satori
+ * requirement). Server-only.
+ */
+export function CommentShareCard({
+  card,
+  logoDataUri,
+  format = "square",
+}: {
+  card: CommentCardProps;
+  logoDataUri: string;
+  format?: "square" | "wide";
+}) {
+  const wide = format === "wide";
+  const pad = wide ? 64 : 88;
+  const textSize = wide ? 40 : 52;
+  const brand = "#1075d3";
+  const metas = getTagMetas(card.tags);
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#ffffff",
+        padding: pad,
+        fontFamily: "sans-serif",
+      }}
+    >
+      {/* Header: logo + wordmark */}
+      <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={logoDataUri} alt="" width={wide ? 52 : 64} height={wide ? 52 : 64} />
+        <div style={{ display: "flex", fontSize: wide ? 30 : 36, fontWeight: 700, color: brand }}>
+          Bible Comment
+        </div>
+      </div>
+
+      {/* Body: reference + comment text */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 28, flex: 1, justifyContent: "center", paddingTop: 36, paddingBottom: 36 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          <div
+            style={{
+              display: "flex",
+              background: "rgba(16,117,211,0.10)",
+              color: brand,
+              fontWeight: 700,
+              fontSize: wide ? 26 : 32,
+              padding: "8px 20px",
+              borderRadius: 14,
+            }}
+          >
+            {card.reference}
+          </div>
+          {card.verified && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: wide ? 34 : 40,
+                height: wide ? 34 : 40,
+                borderRadius: 999,
+                background: "rgba(5,150,105,0.12)",
+                color: "#059669",
+                fontSize: wide ? 22 : 26,
+                fontWeight: 800,
+              }}
+            >
+              ✓
+            </div>
+          )}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: textSize,
+            lineHeight: 1.35,
+            color: "#1e293b",
+            fontWeight: 500,
+          }}
+        >
+          {`“${card.text}”`}
+        </div>
+      </div>
+
+      {/* Footer: author + tags + url */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+          {metas.map((m) => (
+            <div
+              key={m.label}
+              style={{
+                display: "flex",
+                background: m.bg,
+                color: m.color,
+                fontWeight: 700,
+                fontSize: wide ? 22 : 26,
+                padding: "6px 16px",
+                borderRadius: 999,
+              }}
+            >
+              {m.label}
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div style={{ display: "flex", fontSize: wide ? 26 : 32, fontWeight: 700, color: "#334155" }}>
+            {`@${card.username}`}
+          </div>
+          <div style={{ display: "flex", fontSize: wide ? 22 : 26, color: brand, fontWeight: 600 }}>
+            biblecomment
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nextjs/src/components/CommentShareCard.tsx
+++ b/nextjs/src/components/CommentShareCard.tsx
@@ -7,119 +7,161 @@ import type { CommentCardProps } from "@/lib/share-comment";
  * requirement). Server-only.
  */
 export function CommentShareCard({
-  card,
-  logoDataUri,
-  format = "square",
+	card,
+	logoDataUri,
+	format = "square",
 }: {
-  card: CommentCardProps;
-  logoDataUri: string;
-  format?: "square" | "wide";
+	card: CommentCardProps;
+	logoDataUri: string;
+	format?: "square" | "wide";
 }) {
-  const wide = format === "wide";
-  const pad = wide ? 64 : 88;
-  const textSize = wide ? 40 : 52;
-  const brand = "#1075d3";
-  const metas = getTagMetas(card.tags);
+	const wide = format === "wide";
+	const pad = wide ? 64 : 88;
+	const textSize = wide ? 40 : 52;
+	const brand = "#1075d3";
+	const metas = getTagMetas(card.tags);
 
-  return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-between",
-        background: "#ffffff",
-        padding: pad,
-        fontFamily: "sans-serif",
-      }}
-    >
-      {/* Header: logo + wordmark */}
-      <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={logoDataUri} alt="" width={wide ? 52 : 64} height={wide ? 52 : 64} />
-        <div style={{ display: "flex", fontSize: wide ? 30 : 36, fontWeight: 700, color: brand }}>
-          Bible Comment
-        </div>
-      </div>
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				background: "#ffffff",
+				padding: pad,
+				fontFamily: "sans-serif",
+			}}
+		>
+			{/* Header: logo + wordmark */}
+			<div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+				{/* eslint-disable-next-line @next/next/no-img-element */}
+				<img
+					src={logoDataUri}
+					alt=""
+					width={wide ? 52 : 64}
+					height={wide ? 52 : 64}
+				/>
+				<div
+					style={{
+						display: "flex",
+						fontSize: wide ? 30 : 36,
+						fontWeight: 700,
+						color: brand,
+					}}
+				>
+					Bible Comment
+				</div>
+			</div>
 
-      {/* Body: reference + comment text */}
-      <div style={{ display: "flex", flexDirection: "column", gap: 28, flex: 1, justifyContent: "center", paddingTop: 36, paddingBottom: 36 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-          <div
-            style={{
-              display: "flex",
-              background: "rgba(16,117,211,0.10)",
-              color: brand,
-              fontWeight: 700,
-              fontSize: wide ? 26 : 32,
-              padding: "8px 20px",
-              borderRadius: 14,
-            }}
-          >
-            {card.reference}
-          </div>
-          {card.verified && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                width: wide ? 34 : 40,
-                height: wide ? 34 : 40,
-                borderRadius: 999,
-                background: "rgba(5,150,105,0.12)",
-                color: "#059669",
-                fontSize: wide ? 22 : 26,
-                fontWeight: 800,
-              }}
-            >
-              ✓
-            </div>
-          )}
-        </div>
-        <div
-          style={{
-            display: "flex",
-            fontSize: textSize,
-            lineHeight: 1.35,
-            color: "#1e293b",
-            fontWeight: 500,
-          }}
-        >
-          {`“${card.text}”`}
-        </div>
-      </div>
+			{/* Body: reference + comment text */}
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					gap: 28,
+					flex: 1,
+					justifyContent: "center",
+					paddingTop: 36,
+					paddingBottom: 36,
+				}}
+			>
+				<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+					<div
+						style={{
+							display: "flex",
+							background: "rgba(16,117,211,0.10)",
+							color: brand,
+							fontWeight: 700,
+							fontSize: wide ? 26 : 32,
+							padding: "8px 20px",
+							borderRadius: 14,
+						}}
+					>
+						{card.reference}
+					</div>
+					{card.verified && (
+						<div
+							style={{
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								width: wide ? 34 : 40,
+								height: wide ? 34 : 40,
+								borderRadius: 999,
+								background: "rgba(5,150,105,0.12)",
+								color: "#059669",
+								fontSize: wide ? 22 : 26,
+								fontWeight: 800,
+							}}
+						>
+							✓
+						</div>
+					)}
+				</div>
+				<div
+					style={{
+						display: "flex",
+						fontSize: textSize,
+						lineHeight: 1.35,
+						color: "#1e293b",
+						fontWeight: 500,
+					}}
+				>
+					{`“${card.text}”`}
+				</div>
+			</div>
 
-      {/* Footer: author + tags + url */}
-      <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
-          {metas.map((m) => (
-            <div
-              key={m.label}
-              style={{
-                display: "flex",
-                background: m.bg,
-                color: m.color,
-                fontWeight: 700,
-                fontSize: wide ? 22 : 26,
-                padding: "6px 16px",
-                borderRadius: 999,
-              }}
-            >
-              {m.label}
-            </div>
-          ))}
-        </div>
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <div style={{ display: "flex", fontSize: wide ? 26 : 32, fontWeight: 700, color: "#334155" }}>
-            {`@${card.username}`}
-          </div>
-          <div style={{ display: "flex", fontSize: wide ? 22 : 26, color: brand, fontWeight: 600 }}>
-            biblecomment
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+			{/* Footer: author + tags + url */}
+			<div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+				<div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+					{metas.map((m) => (
+						<div
+							key={m.label}
+							style={{
+								display: "flex",
+								background: m.bg,
+								color: m.color,
+								fontWeight: 700,
+								fontSize: wide ? 22 : 26,
+								padding: "6px 16px",
+								borderRadius: 999,
+							}}
+						>
+							{m.label}
+						</div>
+					))}
+				</div>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							fontSize: wide ? 26 : 32,
+							fontWeight: 700,
+							color: "#334155",
+						}}
+					>
+						{`@${card.username}`}
+					</div>
+					<div
+						style={{
+							display: "flex",
+							fontSize: wide ? 22 : 26,
+							color: brand,
+							fontWeight: 600,
+						}}
+					>
+						biblecomment
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/nextjs/src/components/Modal.tsx
+++ b/nextjs/src/components/Modal.tsx
@@ -103,7 +103,7 @@ export default function Modal({
     : { "aria-label": ariaLabel ?? "Diálogo" };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center pt-16 px-4">
+    <div className="fixed inset-0 z-50 flex items-start md:items-center justify-center pt-16 md:pt-0 px-4">
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
         onClick={onClose}

--- a/nextjs/src/components/Modal.tsx
+++ b/nextjs/src/components/Modal.tsx
@@ -4,138 +4,143 @@ import React, { useEffect, useCallback, useRef, useId } from "react";
 import Image from "next/image";
 
 interface ModalProps {
-  show: boolean;
-  onClose: () => void;
-  children: React.ReactNode;
-  title?: string;
-  size?: "sm" | "md" | "lg" | "xl" | "2xl";
-  noPadding?: boolean;
-  ariaLabel?: string;
+	show: boolean;
+	onClose: () => void;
+	children: React.ReactNode;
+	title?: string;
+	size?: "sm" | "md" | "lg" | "xl" | "2xl";
+	noPadding?: boolean;
+	ariaLabel?: string;
 }
 
 const SIZE_CLASSES: Record<string, string> = {
-  sm: "max-w-sm",
-  md: "max-w-md",
-  lg: "max-w-lg",
-  xl: "max-w-4xl",
-  "2xl": "max-w-[960px]",
+	sm: "max-w-sm",
+	md: "max-w-md",
+	lg: "max-w-lg",
+	xl: "max-w-4xl",
+	"2xl": "max-w-[960px]",
 };
 
 const FOCUSABLE = [
-  "a[href]",
-  "area[href]",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  "button:not([disabled])",
-  "iframe",
-  "object",
-  "embed",
-  "[contenteditable]",
-  '[tabindex]:not([tabindex="-1"])',
+	"a[href]",
+	"area[href]",
+	"input:not([disabled])",
+	"select:not([disabled])",
+	"textarea:not([disabled])",
+	"button:not([disabled])",
+	"iframe",
+	"object",
+	"embed",
+	"[contenteditable]",
+	'[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
 export default function Modal({
-  show,
-  onClose,
-  children,
-  title,
-  size = "lg",
-  noPadding = false,
-  ariaLabel,
+	show,
+	onClose,
+	children,
+	title,
+	size = "lg",
+	noPadding = false,
+	ariaLabel,
 }: ModalProps) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const previousActiveRef = useRef<HTMLElement | null>(null);
-  const titleId = useId();
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const previousActiveRef = useRef<HTMLElement | null>(null);
+	const titleId = useId();
 
-  const handleKey = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab" || !dialogRef.current) return;
-      const focusable = dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE);
-      if (focusable.length === 0) {
-        e.preventDefault();
-        dialogRef.current.focus();
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    },
-    [onClose]
-  );
+	const handleKey = useCallback(
+		(e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				onClose();
+				return;
+			}
+			if (e.key !== "Tab" || !dialogRef.current) return;
+			const focusable =
+				dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE);
+			if (focusable.length === 0) {
+				e.preventDefault();
+				dialogRef.current.focus();
+				return;
+			}
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+			const active = document.activeElement as HTMLElement | null;
+			if (e.shiftKey && active === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && active === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		},
+		[onClose],
+	);
 
-  useEffect(() => {
-    if (!show) return;
-    previousActiveRef.current = document.activeElement as HTMLElement | null;
-    document.addEventListener("keydown", handleKey);
-    document.body.style.overflow = "hidden";
+	useEffect(() => {
+		if (!show) return;
+		previousActiveRef.current = document.activeElement as HTMLElement | null;
+		document.addEventListener("keydown", handleKey);
+		document.body.style.overflow = "hidden";
 
-    const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE);
-    if (focusable && focusable.length > 0) {
-      focusable[0].focus();
-    } else {
-      dialogRef.current?.focus();
-    }
+		const focusable =
+			dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE);
+		if (focusable && focusable.length > 0) {
+			focusable[0].focus();
+		} else {
+			dialogRef.current?.focus();
+		}
 
-    return () => {
-      document.removeEventListener("keydown", handleKey);
-      document.body.style.overflow = "";
-      previousActiveRef.current?.focus?.();
-    };
-  }, [show, handleKey]);
+		return () => {
+			document.removeEventListener("keydown", handleKey);
+			document.body.style.overflow = "";
+			previousActiveRef.current?.focus?.();
+		};
+	}, [show, handleKey]);
 
-  if (!show) return null;
+	if (!show) return null;
 
-  const labelledBy = title ? titleId : undefined;
-  const labelProp = labelledBy
-    ? { "aria-labelledby": labelledBy }
-    : { "aria-label": ariaLabel ?? "Diálogo" };
+	const labelledBy = title ? titleId : undefined;
+	const labelProp = labelledBy
+		? { "aria-labelledby": labelledBy }
+		: { "aria-label": ariaLabel ?? "Diálogo" };
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-start md:items-center justify-center pt-16 md:pt-0 px-4">
-      <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
-        aria-hidden="true"
-      />
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        {...labelProp}
-        className={`relative z-10 bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full ${SIZE_CLASSES[size] ?? SIZE_CLASSES.lg} max-h-[80vh] flex flex-col overflow-hidden focus:outline-none`}
-      >
-        {title && (
-          <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-slate-800 shrink-0">
-            <h2 id={titleId} className="font-semibold text-gray-800 dark:text-slate-100">
-              {title}
-            </h2>
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex items-center justify-center w-7 h-7 rounded-full text-gray-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-800 transition"
-              aria-label="Fechar"
-            >
-              <Image src="/assets/x.svg" alt="" width={14} height={14} />
-            </button>
-          </div>
-        )}
-        <div className={`overflow-y-auto flex-1${noPadding ? "" : " p-5"}`}>
-          {children}
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className="fixed inset-0 z-50 flex items-start md:items-center justify-center pt-16 md:pt-0 px-4">
+			<div
+				className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+				onClick={onClose}
+				aria-hidden="true"
+			/>
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				tabIndex={-1}
+				{...labelProp}
+				className={`relative z-10 bg-white dark:bg-slate-900 rounded-2xl shadow-2xl w-full ${SIZE_CLASSES[size] ?? SIZE_CLASSES.lg} max-h-[80vh] flex flex-col overflow-hidden focus:outline-none`}
+			>
+				{title && (
+					<div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-slate-800 shrink-0">
+						<h2
+							id={titleId}
+							className="font-semibold text-gray-800 dark:text-slate-100"
+						>
+							{title}
+						</h2>
+						<button
+							type="button"
+							onClick={onClose}
+							className="flex items-center justify-center w-7 h-7 rounded-full text-gray-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-gray-100 dark:hover:bg-slate-800 transition"
+							aria-label="Fechar"
+						>
+							<Image src="/assets/x.svg" alt="" width={14} height={14} />
+						</button>
+					</div>
+				)}
+				<div className={`overflow-y-auto flex-1${noPadding ? "" : " p-5"}`}>
+					{children}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/nextjs/src/components/ShareCommentButton.tsx
+++ b/nextjs/src/components/ShareCommentButton.tsx
@@ -35,8 +35,7 @@ export function ShareCommentButton({
 	// Derive once per input change — otherwise these recompute every render
 	// and defeat the useCallback memoization of onWebShare / onCopy.
 	const { shareUrl, ogUrl, shareText } = useMemo(() => {
-		const origin =
-			typeof window !== "undefined" ? window.location.origin : "";
+		const origin = typeof window !== "undefined" ? window.location.origin : "";
 		const url = formatCommentShareUrl(commentId, origin);
 		return {
 			shareUrl: url,
@@ -62,9 +61,7 @@ export function ShareCommentButton({
 			try {
 				const ctrl = new AbortController();
 				const timer = setTimeout(() => ctrl.abort(), 1500);
-				const blob = await (
-					await fetch(ogUrl, { signal: ctrl.signal })
-				).blob();
+				const blob = await (await fetch(ogUrl, { signal: ctrl.signal })).blob();
 				clearTimeout(timer);
 				const file = new File([blob], "comentario.png", {
 					type: "image/png",

--- a/nextjs/src/components/ShareCommentButton.tsx
+++ b/nextjs/src/components/ShareCommentButton.tsx
@@ -4,151 +4,151 @@ import { useState, useCallback } from "react";
 import Modal from "@/components/Modal";
 import { useNotification } from "@/contexts/NotificationContext";
 import {
-  formatCommentShareUrl,
-  formatCommentShare,
-  clampForCard,
+	formatCommentShareUrl,
+	formatCommentShare,
+	clampForCard,
 } from "@/lib/share-comment";
 
 interface Props {
-  commentId: string;
-  text: string;
-  username: string;
-  /** Human reference, e.g. "Gênesis 1:1" (comment.bookReference). */
-  reference: string;
-  className?: string;
+	commentId: string;
+	text: string;
+	username: string;
+	/** Human reference, e.g. "Gênesis 1:1" (comment.bookReference). */
+	reference: string;
+	className?: string;
 }
 
 const ICON_BTN =
-  "flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap ml-0.5";
+	"flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap ml-0.5";
 
 export function ShareCommentButton({
-  commentId,
-  text,
-  username,
-  reference,
-  className = "",
+	commentId,
+	text,
+	username,
+	reference,
+	className = "",
 }: Props) {
-  const { handleNotification } = useNotification();
-  const [open, setOpen] = useState(false);
+	const { handleNotification } = useNotification();
+	const [open, setOpen] = useState(false);
 
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const shareUrl = formatCommentShareUrl(commentId, origin);
-  const ogUrl = `${origin}/api/og/comment/${commentId}`;
-  const shareText = formatCommentShare(
-    { text: clampForCard(text), username, reference },
-    shareUrl,
-  );
+	const origin = typeof window !== "undefined" ? window.location.origin : "";
+	const shareUrl = formatCommentShareUrl(commentId, origin);
+	const ogUrl = `${origin}/api/og/comment/${commentId}`;
+	const shareText = formatCommentShare(
+		{ text: clampForCard(text), username, reference },
+		shareUrl,
+	);
 
-  const onWebShare = useCallback(async () => {
-    const nav = navigator as Navigator & {
-      canShare?: (d: ShareData) => boolean;
-    };
-    try {
-      // Try sharing the actual image file where supported (iOS Safari etc).
-      try {
-        const blob = await (await fetch(ogUrl)).blob();
-        const file = new File([blob], "comentario.png", { type: "image/png" });
-        if (nav.canShare?.({ files: [file] })) {
-          await nav.share({ files: [file], text: shareText, url: shareUrl });
-          return;
-        }
-      } catch {
-        /* fall through to text/url share */
-      }
-      await nav.share({ text: shareText, url: shareUrl });
-    } catch (e) {
-      // User dismissed the native sheet — not an error.
-      if ((e as Error)?.name !== "AbortError") {
-        handleNotification("error", "Não foi possível compartilhar.");
-      }
-    }
-  }, [ogUrl, shareText, shareUrl, handleNotification]);
+	const onWebShare = useCallback(async () => {
+		const nav = navigator as Navigator & {
+			canShare?: (d: ShareData) => boolean;
+		};
+		try {
+			// Try sharing the actual image file where supported (iOS Safari etc).
+			try {
+				const blob = await (await fetch(ogUrl)).blob();
+				const file = new File([blob], "comentario.png", { type: "image/png" });
+				if (nav.canShare?.({ files: [file] })) {
+					await nav.share({ files: [file], text: shareText, url: shareUrl });
+					return;
+				}
+			} catch {
+				/* fall through to text/url share */
+			}
+			await nav.share({ text: shareText, url: shareUrl });
+		} catch (e) {
+			// User dismissed the native sheet — not an error.
+			if ((e as Error)?.name !== "AbortError") {
+				handleNotification("error", "Não foi possível compartilhar.");
+			}
+		}
+	}, [ogUrl, shareText, shareUrl, handleNotification]);
 
-  const onCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(shareText);
-      handleNotification("success", "Link e texto copiados.");
-    } catch {
-      handleNotification("error", "Não foi possível copiar.");
-    }
-  }, [shareText, handleNotification]);
+	const onCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(shareText);
+			handleNotification("success", "Link e texto copiados.");
+		} catch {
+			handleNotification("error", "Não foi possível copiar.");
+		}
+	}, [shareText, handleNotification]);
 
-  const canWebShare =
-    typeof navigator !== "undefined" && typeof navigator.share === "function";
+	const canWebShare =
+		typeof navigator !== "undefined" && typeof navigator.share === "function";
 
-  return (
-    <>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen(true);
-        }}
-        title="Compartilhar comentário"
-        aria-label="Compartilhar comentário"
-        className={`${ICON_BTN} ${className}`}
-      >
-        <svg
-          width="13"
-          height="13"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <circle cx="18" cy="5" r="3" />
-          <circle cx="6" cy="12" r="3" />
-          <circle cx="18" cy="19" r="3" />
-          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-        </svg>
-        Compartilhar
-      </button>
+	return (
+		<>
+			<button
+				type="button"
+				onClick={(e) => {
+					e.stopPropagation();
+					setOpen(true);
+				}}
+				title="Compartilhar comentário"
+				aria-label="Compartilhar comentário"
+				className={`${ICON_BTN} ${className}`}
+			>
+				<svg
+					width="13"
+					height="13"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<circle cx="18" cy="5" r="3" />
+					<circle cx="6" cy="12" r="3" />
+					<circle cx="18" cy="19" r="3" />
+					<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+					<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+				</svg>
+				Compartilhar
+			</button>
 
-      <Modal
-        show={open}
-        onClose={() => setOpen(false)}
-        title="Compartilhar comentário"
-        size="md"
-        ariaLabel="Compartilhar comentário"
-      >
-        <div className="flex flex-col gap-4">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={ogUrl}
-            alt="Pré-visualização do card do comentário"
-            className="w-full rounded-xl border border-slate-200 dark:border-slate-700"
-          />
-          <div className="flex flex-wrap gap-2">
-            {canWebShare && (
-              <button
-                type="button"
-                onClick={onWebShare}
-                className="flex-1 min-w-[120px] bg-brand text-white text-sm font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition"
-              >
-                Compartilhar
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={onCopy}
-              className="flex-1 min-w-[120px] border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 transition"
-            >
-              Copiar link + texto
-            </button>
-            <a
-              href={ogUrl}
-              download="comentario.png"
-              className="flex-1 min-w-[120px] text-center border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 transition"
-            >
-              Baixar imagem
-            </a>
-          </div>
-        </div>
-      </Modal>
-    </>
-  );
+			<Modal
+				show={open}
+				onClose={() => setOpen(false)}
+				title="Compartilhar comentário"
+				size="md"
+				ariaLabel="Compartilhar comentário"
+			>
+				<div className="flex flex-col gap-4">
+					{/* eslint-disable-next-line @next/next/no-img-element */}
+					<img
+						src={ogUrl}
+						alt="Pré-visualização do card do comentário"
+						className="w-full rounded-xl border border-slate-200 dark:border-slate-700"
+					/>
+					<div className="flex flex-wrap gap-2">
+						{canWebShare && (
+							<button
+								type="button"
+								onClick={onWebShare}
+								className="flex-1 min-w-[120px] bg-brand text-white text-sm font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition"
+							>
+								Compartilhar
+							</button>
+						)}
+						<button
+							type="button"
+							onClick={onCopy}
+							className="flex-1 min-w-[120px] border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 transition"
+						>
+							Copiar link + texto
+						</button>
+						<a
+							href={ogUrl}
+							download="comentario.png"
+							className="flex-1 min-w-[120px] text-center border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 transition"
+						>
+							Baixar imagem
+						</a>
+					</div>
+				</div>
+			</Modal>
+		</>
+	);
 }

--- a/nextjs/src/components/ShareCommentButton.tsx
+++ b/nextjs/src/components/ShareCommentButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import Modal from "@/components/Modal";
 import { useNotification } from "@/contexts/NotificationContext";
 import {
@@ -30,30 +30,51 @@ export function ShareCommentButton({
 }: Props) {
 	const { handleNotification } = useNotification();
 	const [open, setOpen] = useState(false);
+	const [sharing, setSharing] = useState(false);
 
-	const origin = typeof window !== "undefined" ? window.location.origin : "";
-	const shareUrl = formatCommentShareUrl(commentId, origin);
-	const ogUrl = `${origin}/api/og/comment/${commentId}`;
-	const shareText = formatCommentShare(
-		{ text: clampForCard(text), username, reference },
-		shareUrl,
-	);
+	// Derive once per input change — otherwise these recompute every render
+	// and defeat the useCallback memoization of onWebShare / onCopy.
+	const { shareUrl, ogUrl, shareText } = useMemo(() => {
+		const origin =
+			typeof window !== "undefined" ? window.location.origin : "";
+		const url = formatCommentShareUrl(commentId, origin);
+		return {
+			shareUrl: url,
+			ogUrl: `${origin}/api/og/comment/${commentId}`,
+			shareText: formatCommentShare(
+				{ text: clampForCard(text), username, reference },
+				url,
+			),
+		};
+	}, [commentId, text, username, reference]);
 
 	const onWebShare = useCallback(async () => {
+		if (sharing) return;
 		const nav = navigator as Navigator & {
 			canShare?: (d: ShareData) => boolean;
 		};
+		setSharing(true);
 		try {
-			// Try sharing the actual image file where supported (iOS Safari etc).
+			// Try sharing the actual image file where supported (iOS Safari
+			// etc). The OG endpoint can be slow (satori render) — cap the
+			// wait at 1.5s so we don't lose the user-activation gesture;
+			// fall back to text+url share if it doesn't resolve in time.
 			try {
-				const blob = await (await fetch(ogUrl)).blob();
-				const file = new File([blob], "comentario.png", { type: "image/png" });
+				const ctrl = new AbortController();
+				const timer = setTimeout(() => ctrl.abort(), 1500);
+				const blob = await (
+					await fetch(ogUrl, { signal: ctrl.signal })
+				).blob();
+				clearTimeout(timer);
+				const file = new File([blob], "comentario.png", {
+					type: "image/png",
+				});
 				if (nav.canShare?.({ files: [file] })) {
 					await nav.share({ files: [file], text: shareText, url: shareUrl });
 					return;
 				}
 			} catch {
-				/* fall through to text/url share */
+				/* timeout / unsupported → text+url share */
 			}
 			await nav.share({ text: shareText, url: shareUrl });
 		} catch (e) {
@@ -61,8 +82,10 @@ export function ShareCommentButton({
 			if ((e as Error)?.name !== "AbortError") {
 				handleNotification("error", "Não foi possível compartilhar.");
 			}
+		} finally {
+			setSharing(false);
 		}
-	}, [ogUrl, shareText, shareUrl, handleNotification]);
+	}, [ogUrl, shareText, shareUrl, handleNotification, sharing]);
 
 	const onCopy = useCallback(async () => {
 		try {
@@ -127,9 +150,10 @@ export function ShareCommentButton({
 							<button
 								type="button"
 								onClick={onWebShare}
-								className="flex-1 min-w-[120px] bg-brand text-white text-sm font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition"
+								disabled={sharing}
+								className="flex-1 min-w-[120px] bg-brand text-white text-sm font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition disabled:opacity-60 disabled:cursor-not-allowed"
 							>
-								Compartilhar
+								{sharing ? "Preparando…" : "Compartilhar"}
 							</button>
 						)}
 						<button

--- a/nextjs/src/components/ShareCommentButton.tsx
+++ b/nextjs/src/components/ShareCommentButton.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Modal from "@/components/Modal";
+import { useNotification } from "@/contexts/NotificationContext";
+import {
+  formatCommentShareUrl,
+  formatCommentShare,
+  clampForCard,
+} from "@/lib/share-comment";
+
+interface Props {
+  commentId: string;
+  text: string;
+  username: string;
+  /** Human reference, e.g. "Gênesis 1:1" (comment.bookReference). */
+  reference: string;
+  className?: string;
+}
+
+const ICON_BTN =
+  "flex items-center gap-[5px] px-2 h-[26px] rounded-[5px] border-none bg-transparent cursor-pointer font-medium text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap ml-0.5";
+
+export function ShareCommentButton({
+  commentId,
+  text,
+  username,
+  reference,
+  className = "",
+}: Props) {
+  const { handleNotification } = useNotification();
+  const [open, setOpen] = useState(false);
+
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const shareUrl = formatCommentShareUrl(commentId, origin);
+  const ogUrl = `${origin}/api/og/comment/${commentId}`;
+  const shareText = formatCommentShare(
+    { text: clampForCard(text), username, reference },
+    shareUrl,
+  );
+
+  const onWebShare = useCallback(async () => {
+    const nav = navigator as Navigator & {
+      canShare?: (d: ShareData) => boolean;
+    };
+    try {
+      // Try sharing the actual image file where supported (iOS Safari etc).
+      try {
+        const blob = await (await fetch(ogUrl)).blob();
+        const file = new File([blob], "comentario.png", { type: "image/png" });
+        if (nav.canShare?.({ files: [file] })) {
+          await nav.share({ files: [file], text: shareText, url: shareUrl });
+          return;
+        }
+      } catch {
+        /* fall through to text/url share */
+      }
+      await nav.share({ text: shareText, url: shareUrl });
+    } catch (e) {
+      // User dismissed the native sheet — not an error.
+      if ((e as Error)?.name !== "AbortError") {
+        handleNotification("error", "Não foi possível compartilhar.");
+      }
+    }
+  }, [ogUrl, shareText, shareUrl, handleNotification]);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(shareText);
+      handleNotification("success", "Link e texto copiados.");
+    } catch {
+      handleNotification("error", "Não foi possível copiar.");
+    }
+  }, [shareText, handleNotification]);
+
+  const canWebShare =
+    typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        title="Compartilhar comentário"
+        aria-label="Compartilhar comentário"
+        className={`${ICON_BTN} ${className}`}
+      >
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        </svg>
+        Compartilhar
+      </button>
+
+      <Modal
+        show={open}
+        onClose={() => setOpen(false)}
+        title="Compartilhar comentário"
+        size="md"
+        ariaLabel="Compartilhar comentário"
+      >
+        <div className="flex flex-col gap-4">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={ogUrl}
+            alt="Pré-visualização do card do comentário"
+            className="w-full rounded-xl border border-slate-200 dark:border-slate-700"
+          />
+          <div className="flex flex-wrap gap-2">
+            {canWebShare && (
+              <button
+                type="button"
+                onClick={onWebShare}
+                className="flex-1 min-w-[120px] bg-brand text-white text-sm font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition"
+              >
+                Compartilhar
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onCopy}
+              className="flex-1 min-w-[120px] border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 transition"
+            >
+              Copiar link + texto
+            </button>
+            <a
+              href={ogUrl}
+              download="comentario.png"
+              className="flex-1 min-w-[120px] text-center border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 text-sm font-semibold px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800 transition"
+            >
+              Baixar imagem
+            </a>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/nextjs/src/components/TagBadges.tsx
+++ b/nextjs/src/components/TagBadges.tsx
@@ -2,16 +2,21 @@ import { getTagMetas } from "@/lib/tag-meta";
 import { TagIcon } from "@/components/TagIcon";
 
 interface Props {
-  /** Comment tags; empty/unknown renders the single neutral "Comentário". */
-  tags: string[];
-  /** `sm` (profile/list cards) | `md` (chapter sidebar header). */
-  size?: "sm" | "md";
-  className?: string;
+	/** Comment tags; empty/unknown renders the single neutral "Comentário". */
+	tags: string[];
+	/** `sm` (profile/list cards) | `md` (chapter sidebar header). */
+	size?: "sm" | "md";
+	className?: string;
 }
 
 const SIZES = {
-  sm: { icon: 12, h: "h-[20.5px]", text: "text-[11px] leading-[16.5px]", px: "pl-1.5 pr-2" },
-  md: { icon: 14, h: "h-[22px]", text: "text-xs", px: "pl-2 pr-2.5" },
+	sm: {
+		icon: 12,
+		h: "h-[20.5px]",
+		text: "text-[11px] leading-[16.5px]",
+		px: "pl-1.5 pr-2",
+	},
+	md: { icon: 14, h: "h-[22px]", text: "text-xs", px: "pl-2 pr-2.5" },
 } as const;
 
 /**
@@ -21,26 +26,26 @@ const SIZES = {
  * icon+label so secondary categories are no longer invisible.
  */
 export function TagBadges({ tags, size = "sm", className = "" }: Props) {
-  const sz = SIZES[size];
-  return (
-    <span
-      data-testid="tag-badges"
-      className={`inline-flex flex-wrap items-center gap-1.5 ${className}`}
-    >
-      {getTagMetas(tags).map((meta) => (
-        <span
-          key={meta.label}
-          className={`inline-flex items-center gap-1 rounded-[10px] ${sz.px} ${sz.h} shrink-0`}
-          style={{ background: meta.bg, color: meta.color }}
-        >
-          <span aria-hidden="true" className="flex">
-            <TagIcon name={meta.icon} width={sz.icon} height={sz.icon} />
-          </span>
-          <span className={`font-semibold whitespace-nowrap ${sz.text}`}>
-            {meta.label}
-          </span>
-        </span>
-      ))}
-    </span>
-  );
+	const sz = SIZES[size];
+	return (
+		<span
+			data-testid="tag-badges"
+			className={`inline-flex flex-wrap items-center gap-1.5 ${className}`}
+		>
+			{getTagMetas(tags).map((meta) => (
+				<span
+					key={meta.label}
+					className={`inline-flex items-center gap-1 rounded-[10px] ${sz.px} ${sz.h} shrink-0`}
+					style={{ background: meta.bg, color: meta.color }}
+				>
+					<span aria-hidden="true" className="flex">
+						<TagIcon name={meta.icon} width={sz.icon} height={sz.icon} />
+					</span>
+					<span className={`font-semibold whitespace-nowrap ${sz.text}`}>
+						{meta.label}
+					</span>
+				</span>
+			))}
+		</span>
+	);
 }

--- a/nextjs/src/components/TagBadges.tsx
+++ b/nextjs/src/components/TagBadges.tsx
@@ -2,16 +2,21 @@ import { getTagMetas } from "@/lib/tag-meta";
 import { TagIcon } from "@/components/TagIcon";
 
 interface Props {
-  /** Comment tags; empty/unknown renders the single neutral "Comentário". */
-  tags: string[];
-  /** `sm` (profile/list cards) | `md` (chapter sidebar header). */
-  size?: "sm" | "md";
-  className?: string;
+	/** Comment tags; empty/unknown renders the single neutral "Comentário". */
+	tags: string[];
+	/** `sm` (profile/list cards) | `md` (chapter sidebar header). */
+	size?: "sm" | "md";
+	className?: string;
 }
 
 const SIZES = {
-  sm: { icon: 12, h: "h-[20.5px]", text: "text-[11px] leading-[16.5px]", px: "pl-1.5 pr-2" },
-  md: { icon: 14, h: "h-[22px]", text: "text-xs", px: "pl-2 pr-2.5" },
+	sm: {
+		icon: 12,
+		h: "h-[20.5px]",
+		text: "text-[11px] leading-[16.5px]",
+		px: "pl-1.5 pr-2",
+	},
+	md: { icon: 14, h: "h-[22px]", text: "text-xs", px: "pl-2 pr-2.5" },
 } as const;
 
 /**
@@ -21,26 +26,26 @@ const SIZES = {
  * icon+label so secondary categories are no longer invisible.
  */
 export function TagBadges({ tags, size = "sm", className = "" }: Props) {
-  const s = SIZES[size];
-  return (
-    <span
-      data-testid="tag-badges"
-      className={`inline-flex flex-wrap items-center gap-1.5 ${className}`}
-    >
-      {getTagMetas(tags).map((meta) => (
-        <span
-          key={meta.label}
-          className={`inline-flex items-center gap-1 rounded-[10px] ${s.px} ${s.h} shrink-0`}
-          style={{ background: meta.bg, color: meta.color }}
-        >
-          <span aria-hidden="true" className="flex">
-            <TagIcon name={meta.icon} width={s.icon} height={s.icon} />
-          </span>
-          <span className={`font-semibold whitespace-nowrap ${s.text}`}>
-            {meta.label}
-          </span>
-        </span>
-      ))}
-    </span>
-  );
+	const s = SIZES[size];
+	return (
+		<span
+			data-testid="tag-badges"
+			className={`inline-flex flex-wrap items-center gap-1.5 ${className}`}
+		>
+			{getTagMetas(tags).map((meta) => (
+				<span
+					key={meta.label}
+					className={`inline-flex items-center gap-1 rounded-[10px] ${s.px} ${s.h} shrink-0`}
+					style={{ background: meta.bg, color: meta.color }}
+				>
+					<span aria-hidden="true" className="flex">
+						<TagIcon name={meta.icon} width={s.icon} height={s.icon} />
+					</span>
+					<span className={`font-semibold whitespace-nowrap ${s.text}`}>
+						{meta.label}
+					</span>
+				</span>
+			))}
+		</span>
+	);
 }

--- a/nextjs/src/components/TagBadges.tsx
+++ b/nextjs/src/components/TagBadges.tsx
@@ -21,7 +21,7 @@ const SIZES = {
  * icon+label so secondary categories are no longer invisible.
  */
 export function TagBadges({ tags, size = "sm", className = "" }: Props) {
-  const s = SIZES[size];
+  const sz = SIZES[size];
   return (
     <span
       data-testid="tag-badges"
@@ -30,13 +30,13 @@ export function TagBadges({ tags, size = "sm", className = "" }: Props) {
       {getTagMetas(tags).map((meta) => (
         <span
           key={meta.label}
-          className={`inline-flex items-center gap-1 rounded-[10px] ${s.px} ${s.h} shrink-0`}
+          className={`inline-flex items-center gap-1 rounded-[10px] ${sz.px} ${sz.h} shrink-0`}
           style={{ background: meta.bg, color: meta.color }}
         >
           <span aria-hidden="true" className="flex">
-            <TagIcon name={meta.icon} width={s.icon} height={s.icon} />
+            <TagIcon name={meta.icon} width={sz.icon} height={sz.icon} />
           </span>
-          <span className={`font-semibold whitespace-nowrap ${s.text}`}>
+          <span className={`font-semibold whitespace-nowrap ${sz.text}`}>
             {meta.label}
           </span>
         </span>

--- a/nextjs/src/components/TagBadges.tsx
+++ b/nextjs/src/components/TagBadges.tsx
@@ -1,0 +1,46 @@
+import { getTagMetas } from "@/lib/tag-meta";
+import { TagIcon } from "@/components/TagIcon";
+
+interface Props {
+  /** Comment tags; empty/unknown renders the single neutral "Comentário". */
+  tags: string[];
+  /** `sm` (profile/list cards) | `md` (chapter sidebar header). */
+  size?: "sm" | "md";
+  className?: string;
+}
+
+const SIZES = {
+  sm: { icon: 12, h: "h-[20.5px]", text: "text-[11px] leading-[16.5px]", px: "pl-1.5 pr-2" },
+  md: { icon: 14, h: "h-[22px]", text: "text-xs", px: "pl-2 pr-2.5" },
+} as const;
+
+/**
+ * Renders ALL of a comment's categories as a row of colored pills, ordered
+ * most-personal → most-studied (see getTagMetas). Pure/presentational —
+ * safe in server and client components. Replaces the legacy single-tag
+ * icon+label so secondary categories are no longer invisible.
+ */
+export function TagBadges({ tags, size = "sm", className = "" }: Props) {
+  const s = SIZES[size];
+  return (
+    <span
+      data-testid="tag-badges"
+      className={`inline-flex flex-wrap items-center gap-1.5 ${className}`}
+    >
+      {getTagMetas(tags).map((meta) => (
+        <span
+          key={meta.label}
+          className={`inline-flex items-center gap-1 rounded-[10px] ${s.px} ${s.h} shrink-0`}
+          style={{ background: meta.bg, color: meta.color }}
+        >
+          <span aria-hidden="true" className="flex">
+            <TagIcon name={meta.icon} width={s.icon} height={s.icon} />
+          </span>
+          <span className={`font-semibold whitespace-nowrap ${s.text}`}>
+            {meta.label}
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/nextjs/src/lib/share-comment.test.ts
+++ b/nextjs/src/lib/share-comment.test.ts
@@ -1,102 +1,111 @@
 import { describe, it, expect } from "vitest";
 import {
-  formatCommentShareUrl,
-  formatCommentReference,
-  verseDeepLinkPath,
-  clampForCard,
-  formatCommentShare,
-  commentToCardProps,
+	formatCommentShareUrl,
+	formatCommentReference,
+	verseDeepLinkPath,
+	clampForCard,
+	formatCommentShare,
+	commentToCardProps,
 } from "./share-comment";
 
-const verse = { abbrev: "gn", chapter: 1, verseNumber: 1, reference: "Gênesis 1:1" };
+const verse = {
+	abbrev: "gn",
+	chapter: 1,
+	verseNumber: 1,
+	reference: "Gênesis 1:1",
+};
 
 describe("formatCommentShareUrl", () => {
-  it("composes the canonical /c/<id> URL from origin", () => {
-    expect(formatCommentShareUrl("abc123", "https://app.example.com")).toBe(
-      "https://app.example.com/c/abc123",
-    );
-  });
-  it("strips trailing slashes from origin", () => {
-    expect(formatCommentShareUrl("abc123", "https://app.example.com///")).toBe(
-      "https://app.example.com/c/abc123",
-    );
-  });
+	it("composes the canonical /c/<id> URL from origin", () => {
+		expect(formatCommentShareUrl("abc123", "https://app.example.com")).toBe(
+			"https://app.example.com/c/abc123",
+		);
+	});
+	it("strips trailing slashes from origin", () => {
+		expect(formatCommentShareUrl("abc123", "https://app.example.com///")).toBe(
+			"https://app.example.com/c/abc123",
+		);
+	});
 });
 
 describe("formatCommentReference", () => {
-  it("prefers the comment's stored bookReference", () => {
-    expect(
-      formatCommentReference({ bookReference: "João 3:16" }, verse),
-    ).toBe("João 3:16");
-  });
-  it("prefers the verse's own reference when the comment has none", () => {
-    expect(formatCommentReference({}, verse)).toBe("Gênesis 1:1");
-  });
-  it("derives ABBREV chap:verse when neither comment nor verse has a reference", () => {
-    expect(
-      formatCommentReference({}, { ...verse, reference: undefined }),
-    ).toBe("GN 1:1");
-  });
+	it("prefers the comment's stored bookReference", () => {
+		expect(formatCommentReference({ bookReference: "João 3:16" }, verse)).toBe(
+			"João 3:16",
+		);
+	});
+	it("prefers the verse's own reference when the comment has none", () => {
+		expect(formatCommentReference({}, verse)).toBe("Gênesis 1:1");
+	});
+	it("derives ABBREV chap:verse when neither comment nor verse has a reference", () => {
+		expect(formatCommentReference({}, { ...verse, reference: undefined })).toBe(
+			"GN 1:1",
+		);
+	});
 });
 
 describe("verseDeepLinkPath", () => {
-  it("builds the in-app verse hash path", () => {
-    expect(verseDeepLinkPath(verse)).toBe("/verses/gn/1#1");
-  });
+	it("builds the in-app verse hash path", () => {
+		expect(verseDeepLinkPath(verse)).toBe("/verses/gn/1#1");
+	});
 });
 
 describe("clampForCard", () => {
-  it("returns trimmed text unchanged when within the limit", () => {
-    expect(clampForCard("  hello world  ", 280)).toBe("hello world");
-  });
-  it("truncates with an ellipsis and never exceeds max length", () => {
-    const long = "a".repeat(500);
-    const out = clampForCard(long, 280);
-    expect(out.length).toBeLessThanOrEqual(280);
-    expect(out.endsWith("…")).toBe(true);
-  });
-  it("does not add an ellipsis exactly at the boundary", () => {
-    const exact = "x".repeat(280);
-    expect(clampForCard(exact, 280)).toBe(exact);
-  });
+	it("returns trimmed text unchanged when within the limit", () => {
+		expect(clampForCard("  hello world  ", 280)).toBe("hello world");
+	});
+	it("truncates with an ellipsis and never exceeds max length", () => {
+		const long = "a".repeat(500);
+		const out = clampForCard(long, 280);
+		expect(out.length).toBeLessThanOrEqual(280);
+		expect(out.endsWith("…")).toBe(true);
+	});
+	it("does not add an ellipsis exactly at the boundary", () => {
+		const exact = "x".repeat(280);
+		expect(clampForCard(exact, 280)).toBe(exact);
+	});
 });
 
 describe("formatCommentShare", () => {
-  it("formats quoted text, author, reference and link", () => {
-    expect(
-      formatCommentShare(
-        { text: "Texto do comentário", username: "alice", reference: "Gênesis 1:1" },
-        "https://app.example.com/c/abc123",
-      ),
-    ).toBe(
-      '"Texto do comentário" — @alice (Gênesis 1:1)\nhttps://app.example.com/c/abc123',
-    );
-  });
+	it("formats quoted text, author, reference and link", () => {
+		expect(
+			formatCommentShare(
+				{
+					text: "Texto do comentário",
+					username: "alice",
+					reference: "Gênesis 1:1",
+				},
+				"https://app.example.com/c/abc123",
+			),
+		).toBe(
+			'"Texto do comentário" — @alice (Gênesis 1:1)\nhttps://app.example.com/c/abc123',
+		);
+	});
 });
 
 describe("commentToCardProps", () => {
-  it("maps a comment + verse into card props (clamped text, ref, url, deep link)", () => {
-    const props = commentToCardProps(
-      {
-        _id: "abc123",
-        text: "  Um comentário  ",
-        username: "bob",
-        tags: ["exegese", "pessoal"],
-        verified: true,
-        bookReference: "Gênesis 1:1",
-      },
-      verse,
-      "https://app.example.com",
-    );
-    expect(props).toEqual({
-      text: "Um comentário",
-      username: "bob",
-      reference: "Gênesis 1:1",
-      tags: ["exegese", "pessoal"],
-      verified: true,
-      communitySlug: undefined,
-      url: "https://app.example.com/c/abc123",
-      verseHref: "/verses/gn/1#1",
-    });
-  });
+	it("maps a comment + verse into card props (clamped text, ref, url, deep link)", () => {
+		const props = commentToCardProps(
+			{
+				_id: "abc123",
+				text: "  Um comentário  ",
+				username: "bob",
+				tags: ["exegese", "pessoal"],
+				verified: true,
+				bookReference: "Gênesis 1:1",
+			},
+			verse,
+			"https://app.example.com",
+		);
+		expect(props).toEqual({
+			text: "Um comentário",
+			username: "bob",
+			reference: "Gênesis 1:1",
+			tags: ["exegese", "pessoal"],
+			verified: true,
+			communitySlug: undefined,
+			url: "https://app.example.com/c/abc123",
+			verseHref: "/verses/gn/1#1",
+		});
+	});
 });

--- a/nextjs/src/lib/share-comment.test.ts
+++ b/nextjs/src/lib/share-comment.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatCommentShareUrl,
+  formatCommentReference,
+  verseDeepLinkPath,
+  clampForCard,
+  formatCommentShare,
+  commentToCardProps,
+} from "./share-comment";
+
+const verse = { abbrev: "gn", chapter: 1, verseNumber: 1, reference: "Gênesis 1:1" };
+
+describe("formatCommentShareUrl", () => {
+  it("composes the canonical /c/<id> URL from origin", () => {
+    expect(formatCommentShareUrl("abc123", "https://app.example.com")).toBe(
+      "https://app.example.com/c/abc123",
+    );
+  });
+  it("strips trailing slashes from origin", () => {
+    expect(formatCommentShareUrl("abc123", "https://app.example.com///")).toBe(
+      "https://app.example.com/c/abc123",
+    );
+  });
+});
+
+describe("formatCommentReference", () => {
+  it("prefers the comment's stored bookReference", () => {
+    expect(
+      formatCommentReference({ bookReference: "João 3:16" }, verse),
+    ).toBe("João 3:16");
+  });
+  it("prefers the verse's own reference when the comment has none", () => {
+    expect(formatCommentReference({}, verse)).toBe("Gênesis 1:1");
+  });
+  it("derives ABBREV chap:verse when neither comment nor verse has a reference", () => {
+    expect(
+      formatCommentReference({}, { ...verse, reference: undefined }),
+    ).toBe("GN 1:1");
+  });
+});
+
+describe("verseDeepLinkPath", () => {
+  it("builds the in-app verse hash path", () => {
+    expect(verseDeepLinkPath(verse)).toBe("/verses/gn/1#1");
+  });
+});
+
+describe("clampForCard", () => {
+  it("returns trimmed text unchanged when within the limit", () => {
+    expect(clampForCard("  hello world  ", 280)).toBe("hello world");
+  });
+  it("truncates with an ellipsis and never exceeds max length", () => {
+    const long = "a".repeat(500);
+    const out = clampForCard(long, 280);
+    expect(out.length).toBeLessThanOrEqual(280);
+    expect(out.endsWith("…")).toBe(true);
+  });
+  it("does not add an ellipsis exactly at the boundary", () => {
+    const exact = "x".repeat(280);
+    expect(clampForCard(exact, 280)).toBe(exact);
+  });
+});
+
+describe("formatCommentShare", () => {
+  it("formats quoted text, author, reference and link", () => {
+    expect(
+      formatCommentShare(
+        { text: "Texto do comentário", username: "alice", reference: "Gênesis 1:1" },
+        "https://app.example.com/c/abc123",
+      ),
+    ).toBe(
+      '"Texto do comentário" — @alice (Gênesis 1:1)\nhttps://app.example.com/c/abc123',
+    );
+  });
+});
+
+describe("commentToCardProps", () => {
+  it("maps a comment + verse into card props (clamped text, ref, url, deep link)", () => {
+    const props = commentToCardProps(
+      {
+        _id: "abc123",
+        text: "  Um comentário  ",
+        username: "bob",
+        tags: ["exegese", "pessoal"],
+        verified: true,
+        bookReference: "Gênesis 1:1",
+      },
+      verse,
+      "https://app.example.com",
+    );
+    expect(props).toEqual({
+      text: "Um comentário",
+      username: "bob",
+      reference: "Gênesis 1:1",
+      tags: ["exegese", "pessoal"],
+      verified: true,
+      communitySlug: undefined,
+      url: "https://app.example.com/c/abc123",
+      verseHref: "/verses/gn/1#1",
+    });
+  });
+});

--- a/nextjs/src/lib/share-comment.ts
+++ b/nextjs/src/lib/share-comment.ts
@@ -5,58 +5,58 @@
  */
 
 export interface ShareableComment {
-  _id?: string;
-  text: string;
-  username: string;
-  tags?: string[];
-  verified?: boolean;
-  communitySlug?: string;
-  /** Human reference stored on the comment, e.g. "Gênesis 1:1". */
-  bookReference?: string;
+	_id?: string;
+	text: string;
+	username: string;
+	tags?: string[];
+	verified?: boolean;
+	communitySlug?: string;
+	/** Human reference stored on the comment, e.g. "Gênesis 1:1". */
+	bookReference?: string;
 }
 
 export interface ShareVerseCoords {
-  abbrev: string;
-  chapter: number;
-  verseNumber: number;
-  reference?: string;
+	abbrev: string;
+	chapter: number;
+	verseNumber: number;
+	reference?: string;
 }
 
 export interface CommentCardProps {
-  text: string;
-  username: string;
-  reference: string;
-  tags: string[];
-  verified: boolean;
-  communitySlug?: string;
-  /** Canonical absolute share URL (/c/<id>). */
-  url: string;
-  /** In-app verse deep link the /c page forwards humans to. */
-  verseHref: string;
+	text: string;
+	username: string;
+	reference: string;
+	tags: string[];
+	verified: boolean;
+	communitySlug?: string;
+	/** Canonical absolute share URL (/c/<id>). */
+	url: string;
+	/** In-app verse deep link the /c page forwards humans to. */
+	verseHref: string;
 }
 
 /** Canonical absolute share link for a comment. */
 export function formatCommentShareUrl(id: string, origin: string): string {
-  return `${origin.replace(/\/+$/, "")}/c/${id}`;
+	return `${origin.replace(/\/+$/, "")}/c/${id}`;
 }
 
 /** Human reference: stored bookReference wins, else ABBREV chap:verse. */
 export function formatCommentReference(
-  comment: Pick<ShareableComment, "bookReference">,
-  verse?: ShareVerseCoords,
+	comment: Pick<ShareableComment, "bookReference">,
+	verse?: ShareVerseCoords,
 ): string {
-  if (comment.bookReference) return comment.bookReference;
-  if (verse) {
-    return verse.reference
-      ? verse.reference
-      : `${verse.abbrev.toUpperCase()} ${verse.chapter}:${verse.verseNumber}`;
-  }
-  return "";
+	if (comment.bookReference) return comment.bookReference;
+	if (verse) {
+		return verse.reference
+			? verse.reference
+			: `${verse.abbrev.toUpperCase()} ${verse.chapter}:${verse.verseNumber}`;
+	}
+	return "";
 }
 
 /** In-app verse hash path (no origin) for client-side forwarding. */
 export function verseDeepLinkPath(verse: ShareVerseCoords): string {
-  return `/verses/${verse.abbrev}/${verse.chapter}#${verse.verseNumber}`;
+	return `/verses/${verse.abbrev}/${verse.chapter}#${verse.verseNumber}`;
 }
 
 /**
@@ -64,34 +64,34 @@ export function verseDeepLinkPath(verse: ShareVerseCoords): string {
  * text exactly at the boundary is returned untouched (no ellipsis).
  */
 export function clampForCard(text: string, max = 280): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= max) return trimmed;
-  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+	const trimmed = text.trim();
+	if (trimmed.length <= max) return trimmed;
+	return `${trimmed.slice(0, max - 1).trimEnd()}…`;
 }
 
 /** Formatted, copy-pasteable share text + link. */
 export function formatCommentShare(
-  parts: { text: string; username: string; reference: string },
-  url: string,
+	parts: { text: string; username: string; reference: string },
+	url: string,
 ): string {
-  const ref = parts.reference ? ` (${parts.reference})` : "";
-  return `"${parts.text}" — @${parts.username}${ref}\n${url}`;
+	const ref = parts.reference ? ` (${parts.reference})` : "";
+	return `"${parts.text}" — @${parts.username}${ref}\n${url}`;
 }
 
 /** Map a resolved comment (+ its verse) to everything the card needs. */
 export function commentToCardProps(
-  comment: ShareableComment,
-  verse: ShareVerseCoords,
-  origin: string,
+	comment: ShareableComment,
+	verse: ShareVerseCoords,
+	origin: string,
 ): CommentCardProps {
-  return {
-    text: clampForCard(comment.text),
-    username: comment.username,
-    reference: formatCommentReference(comment, verse),
-    tags: comment.tags ?? [],
-    verified: Boolean(comment.verified),
-    communitySlug: comment.communitySlug,
-    url: formatCommentShareUrl(comment._id ?? "", origin),
-    verseHref: verseDeepLinkPath(verse),
-  };
+	return {
+		text: clampForCard(comment.text),
+		username: comment.username,
+		reference: formatCommentReference(comment, verse),
+		tags: comment.tags ?? [],
+		verified: Boolean(comment.verified),
+		communitySlug: comment.communitySlug,
+		url: formatCommentShareUrl(comment._id ?? "", origin),
+		verseHref: verseDeepLinkPath(verse),
+	};
 }

--- a/nextjs/src/lib/share-comment.ts
+++ b/nextjs/src/lib/share-comment.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for sharing a comment as an image card — parallel to
+ * share-verse.ts. No DOM / no Mongoose so it is unit-testable and safe to
+ * import from both the client share button and the server OG route.
+ */
+
+export interface ShareableComment {
+  _id?: string;
+  text: string;
+  username: string;
+  tags?: string[];
+  verified?: boolean;
+  communitySlug?: string;
+  /** Human reference stored on the comment, e.g. "Gênesis 1:1". */
+  bookReference?: string;
+}
+
+export interface ShareVerseCoords {
+  abbrev: string;
+  chapter: number;
+  verseNumber: number;
+  reference?: string;
+}
+
+export interface CommentCardProps {
+  text: string;
+  username: string;
+  reference: string;
+  tags: string[];
+  verified: boolean;
+  communitySlug?: string;
+  /** Canonical absolute share URL (/c/<id>). */
+  url: string;
+  /** In-app verse deep link the /c page forwards humans to. */
+  verseHref: string;
+}
+
+/** Canonical absolute share link for a comment. */
+export function formatCommentShareUrl(id: string, origin: string): string {
+  return `${origin.replace(/\/+$/, "")}/c/${id}`;
+}
+
+/** Human reference: stored bookReference wins, else ABBREV chap:verse. */
+export function formatCommentReference(
+  comment: Pick<ShareableComment, "bookReference">,
+  verse?: ShareVerseCoords,
+): string {
+  if (comment.bookReference) return comment.bookReference;
+  if (verse) {
+    return verse.reference
+      ? verse.reference
+      : `${verse.abbrev.toUpperCase()} ${verse.chapter}:${verse.verseNumber}`;
+  }
+  return "";
+}
+
+/** In-app verse hash path (no origin) for client-side forwarding. */
+export function verseDeepLinkPath(verse: ShareVerseCoords): string {
+  return `/verses/${verse.abbrev}/${verse.chapter}#${verse.verseNumber}`;
+}
+
+/**
+ * Trim and cap card text. Never exceeds `max` (the ellipsis is counted);
+ * text exactly at the boundary is returned untouched (no ellipsis).
+ */
+export function clampForCard(text: string, max = 280): string {
+  const t = text.trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, max - 1).trimEnd()}…`;
+}
+
+/** Formatted, copy-pasteable share text + link. */
+export function formatCommentShare(
+  parts: { text: string; username: string; reference: string },
+  url: string,
+): string {
+  const ref = parts.reference ? ` (${parts.reference})` : "";
+  return `"${parts.text}" — @${parts.username}${ref}\n${url}`;
+}
+
+/** Map a resolved comment (+ its verse) to everything the card needs. */
+export function commentToCardProps(
+  comment: ShareableComment,
+  verse: ShareVerseCoords,
+  origin: string,
+): CommentCardProps {
+  return {
+    text: clampForCard(comment.text),
+    username: comment.username,
+    reference: formatCommentReference(comment, verse),
+    tags: comment.tags ?? [],
+    verified: !!comment.verified,
+    communitySlug: comment.communitySlug,
+    url: formatCommentShareUrl(comment._id ?? "", origin),
+    verseHref: verseDeepLinkPath(verse),
+  };
+}

--- a/nextjs/src/lib/share-comment.ts
+++ b/nextjs/src/lib/share-comment.ts
@@ -64,9 +64,9 @@ export function verseDeepLinkPath(verse: ShareVerseCoords): string {
  * text exactly at the boundary is returned untouched (no ellipsis).
  */
 export function clampForCard(text: string, max = 280): string {
-  const t = text.trim();
-  if (t.length <= max) return t;
-  return `${t.slice(0, max - 1).trimEnd()}…`;
+  const trimmed = text.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
 }
 
 /** Formatted, copy-pasteable share text + link. */
@@ -89,7 +89,7 @@ export function commentToCardProps(
     username: comment.username,
     reference: formatCommentReference(comment, verse),
     tags: comment.tags ?? [],
-    verified: !!comment.verified,
+    verified: Boolean(comment.verified),
     communitySlug: comment.communitySlug,
     url: formatCommentShareUrl(comment._id ?? "", origin),
     verseHref: verseDeepLinkPath(verse),

--- a/nextjs/src/lib/share-comment.ts
+++ b/nextjs/src/lib/share-comment.ts
@@ -5,58 +5,58 @@
  */
 
 export interface ShareableComment {
-  _id?: string;
-  text: string;
-  username: string;
-  tags?: string[];
-  verified?: boolean;
-  communitySlug?: string;
-  /** Human reference stored on the comment, e.g. "Gênesis 1:1". */
-  bookReference?: string;
+	_id?: string;
+	text: string;
+	username: string;
+	tags?: string[];
+	verified?: boolean;
+	communitySlug?: string;
+	/** Human reference stored on the comment, e.g. "Gênesis 1:1". */
+	bookReference?: string;
 }
 
 export interface ShareVerseCoords {
-  abbrev: string;
-  chapter: number;
-  verseNumber: number;
-  reference?: string;
+	abbrev: string;
+	chapter: number;
+	verseNumber: number;
+	reference?: string;
 }
 
 export interface CommentCardProps {
-  text: string;
-  username: string;
-  reference: string;
-  tags: string[];
-  verified: boolean;
-  communitySlug?: string;
-  /** Canonical absolute share URL (/c/<id>). */
-  url: string;
-  /** In-app verse deep link the /c page forwards humans to. */
-  verseHref: string;
+	text: string;
+	username: string;
+	reference: string;
+	tags: string[];
+	verified: boolean;
+	communitySlug?: string;
+	/** Canonical absolute share URL (/c/<id>). */
+	url: string;
+	/** In-app verse deep link the /c page forwards humans to. */
+	verseHref: string;
 }
 
 /** Canonical absolute share link for a comment. */
 export function formatCommentShareUrl(id: string, origin: string): string {
-  return `${origin.replace(/\/+$/, "")}/c/${id}`;
+	return `${origin.replace(/\/+$/, "")}/c/${id}`;
 }
 
 /** Human reference: stored bookReference wins, else ABBREV chap:verse. */
 export function formatCommentReference(
-  comment: Pick<ShareableComment, "bookReference">,
-  verse?: ShareVerseCoords,
+	comment: Pick<ShareableComment, "bookReference">,
+	verse?: ShareVerseCoords,
 ): string {
-  if (comment.bookReference) return comment.bookReference;
-  if (verse) {
-    return verse.reference
-      ? verse.reference
-      : `${verse.abbrev.toUpperCase()} ${verse.chapter}:${verse.verseNumber}`;
-  }
-  return "";
+	if (comment.bookReference) return comment.bookReference;
+	if (verse) {
+		return verse.reference
+			? verse.reference
+			: `${verse.abbrev.toUpperCase()} ${verse.chapter}:${verse.verseNumber}`;
+	}
+	return "";
 }
 
 /** In-app verse hash path (no origin) for client-side forwarding. */
 export function verseDeepLinkPath(verse: ShareVerseCoords): string {
-  return `/verses/${verse.abbrev}/${verse.chapter}#${verse.verseNumber}`;
+	return `/verses/${verse.abbrev}/${verse.chapter}#${verse.verseNumber}`;
 }
 
 /**
@@ -64,34 +64,34 @@ export function verseDeepLinkPath(verse: ShareVerseCoords): string {
  * text exactly at the boundary is returned untouched (no ellipsis).
  */
 export function clampForCard(text: string, max = 280): string {
-  const t = text.trim();
-  if (t.length <= max) return t;
-  return `${t.slice(0, max - 1).trimEnd()}…`;
+	const t = text.trim();
+	if (t.length <= max) return t;
+	return `${t.slice(0, max - 1).trimEnd()}…`;
 }
 
 /** Formatted, copy-pasteable share text + link. */
 export function formatCommentShare(
-  parts: { text: string; username: string; reference: string },
-  url: string,
+	parts: { text: string; username: string; reference: string },
+	url: string,
 ): string {
-  const ref = parts.reference ? ` (${parts.reference})` : "";
-  return `"${parts.text}" — @${parts.username}${ref}\n${url}`;
+	const ref = parts.reference ? ` (${parts.reference})` : "";
+	return `"${parts.text}" — @${parts.username}${ref}\n${url}`;
 }
 
 /** Map a resolved comment (+ its verse) to everything the card needs. */
 export function commentToCardProps(
-  comment: ShareableComment,
-  verse: ShareVerseCoords,
-  origin: string,
+	comment: ShareableComment,
+	verse: ShareVerseCoords,
+	origin: string,
 ): CommentCardProps {
-  return {
-    text: clampForCard(comment.text),
-    username: comment.username,
-    reference: formatCommentReference(comment, verse),
-    tags: comment.tags ?? [],
-    verified: !!comment.verified,
-    communitySlug: comment.communitySlug,
-    url: formatCommentShareUrl(comment._id ?? "", origin),
-    verseHref: verseDeepLinkPath(verse),
-  };
+	return {
+		text: clampForCard(comment.text),
+		username: comment.username,
+		reference: formatCommentReference(comment, verse),
+		tags: comment.tags ?? [],
+		verified: !!comment.verified,
+		communitySlug: comment.communitySlug,
+		url: formatCommentShareUrl(comment._id ?? "", origin),
+		verseHref: verseDeepLinkPath(verse),
+	};
 }

--- a/nextjs/src/lib/tag-meta.test.ts
+++ b/nextjs/src/lib/tag-meta.test.ts
@@ -2,57 +2,57 @@ import { describe, it, expect } from "vitest";
 import { getTagMetas, getTagMetaOrNeutral, TAG_ORDER } from "./tag-meta";
 
 describe("getTagMetas", () => {
-  it("returns the neutral 'Comentário' meta for an empty tag list", () => {
-    const metas = getTagMetas([]);
-    expect(metas).toHaveLength(1);
-    expect(metas[0].label).toBe("Comentário");
-    expect(metas[0].icon).toBe("comment");
-  });
+	it("returns the neutral 'Comentário' meta for an empty tag list", () => {
+		const metas = getTagMetas([]);
+		expect(metas).toHaveLength(1);
+		expect(metas[0].label).toBe("Comentário");
+		expect(metas[0].icon).toBe("comment");
+	});
 
-  it("returns the neutral meta when no tag is a known category", () => {
-    expect(getTagMetas(["nope", "unknown"]).map((m) => m.label)).toEqual([
-      "Comentário",
-    ]);
-  });
+	it("returns the neutral meta when no tag is a known category", () => {
+		expect(getTagMetas(["nope", "unknown"]).map((m) => m.label)).toEqual([
+			"Comentário",
+		]);
+	});
 
-  it("returns a single meta for a single known tag", () => {
-    expect(getTagMetas(["pessoal"]).map((m) => m.label)).toEqual(["Pessoal"]);
-  });
+	it("returns a single meta for a single known tag", () => {
+		expect(getTagMetas(["pessoal"]).map((m) => m.label)).toEqual(["Pessoal"]);
+	});
 
-  it("orders multiple tags most-personal → most-studied regardless of input order", () => {
-    // Input deliberately reversed; output must follow TAG_ORDER
-    // (pessoal → devocional → inspirado → exegese).
-    expect(
-      getTagMetas(["exegese", "inspirado", "devocional", "pessoal"]).map(
-        (m) => m.label,
-      ),
-    ).toEqual(["Pessoal", "Devocional", "Inspirado", "Exegese"]);
-  });
+	it("orders multiple tags most-personal → most-studied regardless of input order", () => {
+		// Input deliberately reversed; output must follow TAG_ORDER
+		// (pessoal → devocional → inspirado → exegese).
+		expect(
+			getTagMetas(["exegese", "inspirado", "devocional", "pessoal"]).map(
+				(m) => m.label,
+			),
+		).toEqual(["Pessoal", "Devocional", "Inspirado", "Exegese"]);
+	});
 
-  it("maps the legacy 'exegetico' alias to Exegese", () => {
-    expect(getTagMetas(["exegetico"]).map((m) => m.label)).toEqual(["Exegese"]);
-  });
+	it("maps the legacy 'exegetico' alias to Exegese", () => {
+		expect(getTagMetas(["exegetico"]).map((m) => m.label)).toEqual(["Exegese"]);
+	});
 
-  it("dedupes the exegese/exegetico alias pair into a single Exegese badge", () => {
-    expect(getTagMetas(["exegese", "exegetico"]).map((m) => m.label)).toEqual([
-      "Exegese",
-    ]);
-  });
+	it("dedupes the exegese/exegetico alias pair into a single Exegese badge", () => {
+		expect(getTagMetas(["exegese", "exegetico"]).map((m) => m.label)).toEqual([
+			"Exegese",
+		]);
+	});
 
-  it("agrees with getTagMetaOrNeutral on the primary (first) meta", () => {
-    expect(getTagMetas(["exegese", "pessoal"])[0]).toEqual(
-      getTagMetaOrNeutral(["exegese", "pessoal"]),
-    );
-  });
+	it("agrees with getTagMetaOrNeutral on the primary (first) meta", () => {
+		expect(getTagMetas(["exegese", "pessoal"])[0]).toEqual(
+			getTagMetaOrNeutral(["exegese", "pessoal"]),
+		);
+	});
 });
 
 describe("TAG_ORDER", () => {
-  it("is ordered from most personal to most studied", () => {
-    expect([...TAG_ORDER]).toEqual([
-      "pessoal",
-      "devocional",
-      "inspirado",
-      "exegese",
-    ]);
-  });
+	it("is ordered from most personal to most studied", () => {
+		expect([...TAG_ORDER]).toEqual([
+			"pessoal",
+			"devocional",
+			"inspirado",
+			"exegese",
+		]);
+	});
 });

--- a/nextjs/src/lib/tag-meta.test.ts
+++ b/nextjs/src/lib/tag-meta.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { getTagMetas, getTagMetaOrNeutral, TAG_ORDER } from "./tag-meta";
+
+describe("getTagMetas", () => {
+  it("returns the neutral 'Comentário' meta for an empty tag list", () => {
+    const metas = getTagMetas([]);
+    expect(metas).toHaveLength(1);
+    expect(metas[0].label).toBe("Comentário");
+    expect(metas[0].icon).toBe("comment");
+  });
+
+  it("returns the neutral meta when no tag is a known category", () => {
+    expect(getTagMetas(["nope", "unknown"]).map((m) => m.label)).toEqual([
+      "Comentário",
+    ]);
+  });
+
+  it("returns a single meta for a single known tag", () => {
+    expect(getTagMetas(["pessoal"]).map((m) => m.label)).toEqual(["Pessoal"]);
+  });
+
+  it("orders multiple tags most-personal → most-studied regardless of input order", () => {
+    // Input deliberately reversed; output must follow TAG_ORDER
+    // (pessoal → devocional → inspirado → exegese).
+    expect(
+      getTagMetas(["exegese", "inspirado", "devocional", "pessoal"]).map(
+        (m) => m.label,
+      ),
+    ).toEqual(["Pessoal", "Devocional", "Inspirado", "Exegese"]);
+  });
+
+  it("maps the legacy 'exegetico' alias to Exegese", () => {
+    expect(getTagMetas(["exegetico"]).map((m) => m.label)).toEqual(["Exegese"]);
+  });
+
+  it("dedupes the exegese/exegetico alias pair into a single Exegese badge", () => {
+    expect(getTagMetas(["exegese", "exegetico"]).map((m) => m.label)).toEqual([
+      "Exegese",
+    ]);
+  });
+
+  it("agrees with getTagMetaOrNeutral on the primary (first) meta", () => {
+    expect(getTagMetas(["exegese", "pessoal"])[0]).toEqual(
+      getTagMetaOrNeutral(["exegese", "pessoal"]),
+    );
+  });
+});
+
+describe("TAG_ORDER", () => {
+  it("is ordered from most personal to most studied", () => {
+    expect([...TAG_ORDER]).toEqual([
+      "pessoal",
+      "devocional",
+      "inspirado",
+      "exegese",
+    ]);
+  });
+});

--- a/nextjs/src/lib/tag-meta.ts
+++ b/nextjs/src/lib/tag-meta.ts
@@ -1,53 +1,88 @@
 export type TagIconName = "sunrise" | "book-open" | "user" | "pen" | "comment";
 
 export interface TagMeta {
-  label: string;
-  color: string;
-  bg: string;
-  border: string;
-  /** Inline SVG icon name; rendered by <TagIcon name=... /> */
-  icon: TagIconName;
+	label: string;
+	color: string;
+	bg: string;
+	border: string;
+	/** Inline SVG icon name; rendered by <TagIcon name=... /> */
+	icon: TagIconName;
 }
 
 // Each tag needs to be visually distinct at a glance. Devocional moved from
 // indigo (#4f46e5) to rose (#e11d48) because it was reading as the same hue
 // as Inspirado's violet (#7c3aed) in the chapter sidebar.
 export const TAG_META: Record<string, TagMeta> = {
-  devocional: { label: "Devocional", color: "#e11d48", bg: "rgba(225,29,72,0.08)",  border: "#e11d48", icon: "sunrise" },
-  exegese:    { label: "Exegese",    color: "#0d9488", bg: "rgba(13,148,136,0.08)", border: "#0d9488", icon: "book-open" },
-  exegetico:  { label: "Exegese",    color: "#0d9488", bg: "rgba(13,148,136,0.08)", border: "#0d9488", icon: "book-open" },
-  pessoal:    { label: "Pessoal",    color: "#d97706", bg: "rgba(217,119,6,0.08)",  border: "#d97706", icon: "user" },
-  inspirado:  { label: "Inspirado",  color: "#7c3aed", bg: "rgba(124,58,237,0.08)", border: "#8b5cf6", icon: "pen" },
+	devocional: {
+		label: "Devocional",
+		color: "#e11d48",
+		bg: "rgba(225,29,72,0.08)",
+		border: "#e11d48",
+		icon: "sunrise",
+	},
+	exegese: {
+		label: "Exegese",
+		color: "#0d9488",
+		bg: "rgba(13,148,136,0.08)",
+		border: "#0d9488",
+		icon: "book-open",
+	},
+	exegetico: {
+		label: "Exegese",
+		color: "#0d9488",
+		bg: "rgba(13,148,136,0.08)",
+		border: "#0d9488",
+		icon: "book-open",
+	},
+	pessoal: {
+		label: "Pessoal",
+		color: "#d97706",
+		bg: "rgba(217,119,6,0.08)",
+		border: "#d97706",
+		icon: "user",
+	},
+	inspirado: {
+		label: "Inspirado",
+		color: "#7c3aed",
+		bg: "rgba(124,58,237,0.08)",
+		border: "#8b5cf6",
+		icon: "pen",
+	},
 };
 
 // Ordered most personal → most studied. Drives badge/compose/edit order and,
 // via getTagMeta, which tag colors the comment card's left border.
-export const TAG_ORDER = ["pessoal", "devocional", "inspirado", "exegese"] as const;
+export const TAG_ORDER = [
+	"pessoal",
+	"devocional",
+	"inspirado",
+	"exegese",
+] as const;
 
 function normalizeTags(tags: string[]): string[] {
-  // "exegetico" is a legacy alias for "exegese" (same TAG_META entry, but
-  // only "exegese" is in TAG_ORDER) — fold it so it isn't dropped.
-  return tags.map((t) => (t === "exegetico" ? "exegese" : t));
+	// "exegetico" is a legacy alias for "exegese" (same TAG_META entry, but
+	// only "exegese" is in TAG_ORDER) — fold it so it isn't dropped.
+	return tags.map((t) => (t === "exegetico" ? "exegese" : t));
 }
 
 export function getTagMeta(tags: string[]): TagMeta | null {
-  const norm = normalizeTags(tags);
-  for (const t of TAG_ORDER) {
-    if (norm.includes(t)) return TAG_META[t];
-  }
-  return null;
+	const norm = normalizeTags(tags);
+	for (const t of TAG_ORDER) {
+		if (norm.includes(t)) return TAG_META[t];
+	}
+	return null;
 }
 
 const NEUTRAL: TagMeta = {
-  label: "Comentário",
-  color: "#64748b",
-  bg: "rgba(100,116,139,0.08)",
-  border: "#64748b",
-  icon: "comment",
+	label: "Comentário",
+	color: "#64748b",
+	bg: "rgba(100,116,139,0.08)",
+	border: "#64748b",
+	icon: "comment",
 };
 
 export function getTagMetaOrNeutral(tags: string[]): TagMeta {
-  return getTagMeta(tags) ?? NEUTRAL;
+	return getTagMeta(tags) ?? NEUTRAL;
 }
 
 /**
@@ -57,9 +92,9 @@ export function getTagMetaOrNeutral(tags: string[]): TagMeta {
  * equals `getTagMetaOrNeutral(t)`.
  */
 export function getTagMetas(tags: string[]): TagMeta[] {
-  const norm = normalizeTags(tags);
-  const metas = TAG_ORDER.filter((t) => norm.includes(t)).map(
-    (t) => TAG_META[t],
-  );
-  return metas.length > 0 ? metas : [NEUTRAL];
+	const norm = normalizeTags(tags);
+	const metas = TAG_ORDER.filter((t) => norm.includes(t)).map(
+		(t) => TAG_META[t],
+	);
+	return metas.length > 0 ? metas : [NEUTRAL];
 }

--- a/nextjs/src/lib/tag-meta.ts
+++ b/nextjs/src/lib/tag-meta.ts
@@ -20,11 +20,20 @@ export const TAG_META: Record<string, TagMeta> = {
   inspirado:  { label: "Inspirado",  color: "#7c3aed", bg: "rgba(124,58,237,0.08)", border: "#8b5cf6", icon: "pen" },
 };
 
-export const TAG_ORDER = ["devocional", "exegese", "pessoal", "inspirado"] as const;
+// Ordered most personal → most studied. Drives badge/compose/edit order and,
+// via getTagMeta, which tag colors the comment card's left border.
+export const TAG_ORDER = ["pessoal", "devocional", "inspirado", "exegese"] as const;
+
+function normalizeTags(tags: string[]): string[] {
+  // "exegetico" is a legacy alias for "exegese" (same TAG_META entry, but
+  // only "exegese" is in TAG_ORDER) — fold it so it isn't dropped.
+  return tags.map((t) => (t === "exegetico" ? "exegese" : t));
+}
 
 export function getTagMeta(tags: string[]): TagMeta | null {
+  const norm = normalizeTags(tags);
   for (const t of TAG_ORDER) {
-    if (tags.includes(t)) return TAG_META[t];
+    if (norm.includes(t)) return TAG_META[t];
   }
   return null;
 }
@@ -39,4 +48,18 @@ const NEUTRAL: TagMeta = {
 
 export function getTagMetaOrNeutral(tags: string[]): TagMeta {
   return getTagMeta(tags) ?? NEUTRAL;
+}
+
+/**
+ * All categories of a comment as ordered, deduped metas (most personal →
+ * most studied). Empty / no-known-tag input yields `[NEUTRAL]` so callers
+ * never special-case the "Comentário" fallback. `getTagMetas(t)[0]` always
+ * equals `getTagMetaOrNeutral(t)`.
+ */
+export function getTagMetas(tags: string[]): TagMeta[] {
+  const norm = normalizeTags(tags);
+  const metas = TAG_ORDER.filter((t) => norm.includes(t)).map(
+    (t) => TAG_META[t],
+  );
+  return metas.length > 0 ? metas : [NEUTRAL];
 }


### PR DESCRIPTION
This pull request implements multi-category tag badges for comments and introduces a new "share as image" feature, allowing users to share comment cards with Open Graph (OG) images and dedicated shareable links. It also improves the comment deletion UX by enabling inline deletion directly from the reader panel, and updates comment displays throughout the app to support multiple categories. The most important changes are grouped below:

**Multi-Category Tag Badges:**

* Replaces single-category badges with `TagBadges` components across the reader (`ChapterClient.tsx`), profile, and public profile pages, displaying all comment categories as colored pills ordered from most personal to most studied. Falls back to a neutral "Comentário" badge if no tags are present. ([nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsxR22-R23](diffhunk://#diff-614f67988c8a8af93d2320b2cb202590fe30e44ff8d17ce7f8244c946d29a51cR22-R23), [nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsxL1015-R1019](diffhunk://#diff-614f67988c8a8af93d2320b2cb202590fe30e44ff8d17ce7f8244c946d29a51cL1015-R1019), [[1]](diffhunk://#diff-9102210f3a0a06006193bb94b831a9d6e3b9d8c9fc0fd941e840146c64801e37L45-R46) [[2]](diffhunk://#diff-9102210f3a0a06006193bb94b831a9d6e3b9d8c9fc0fd941e840146c64801e37L135-R136) [[3]](diffhunk://#diff-9102210f3a0a06006193bb94b831a9d6e3b9d8c9fc0fd941e840146c64801e37L226-R217) [nextjs/src/app/u/[username]/PublicProfileClient.tsxR7](diffhunk://#diff-b822871ba349e8fcd4a77cadaee91ed1ee0258813b7ca5fabee3bc031e9eb8f5R7), [nextjs/src/app/u/[username]/PublicProfileClient.tsxL353-R360](diffhunk://#diff-b822871ba349e8fcd4a77cadaee91ed1ee0258813b7ca5fabee3bc031e9eb8f5L353-R360))
* Updates the favorites filter logic to show multi-tagged comments under each of their categories.

**Share as Image (OG Card) Functionality:**

* Adds a new API route `/api/og/comment/[id]` that generates a PNG image of a comment card for Open Graph sharing, supporting both square and wide formats. ([nextjs/src/app/api/og/comment/[id]/route.tsxR1-R60](diffhunk://#diff-b7190960148c47c9080b9e02aea9b62122da9379eacc11242f94897f34248fedR1-R60))
* Implements a share button in the reader panel that opens a preview modal and provides a shareable link to `/c/<id>`. ([nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsxR1096-R1103](diffhunk://#diff-614f67988c8a8af93d2320b2cb202590fe30e44ff8d17ce7f8244c946d29a51cR1096-R1103))
* Adds a dedicated `/c/[id]` page with OG/Twitter metadata and a client-side redirect for human users to the verse context, preserving SEO unfurling for crawlers. ([nextjs/src/app/c/[id]/page.tsxR1-R51](diffhunk://#diff-1e1bd2ef95893867daa6855b00b4ef8c41c44810e1abd66342e047f20165f9f3R1-R51), [nextjs/src/app/c/[id]/ShareForward.tsxR1-R38](diffhunk://#diff-b9ef2e8bc218f7a6740e7469a5b7acb9c90335240bf4cbc4ac98dbe9df6bfbe8R1-R38))

**Comment Deletion UX Improvements:**

* Enables inline deletion of comments directly from the reader panel for comment authors, with confirmation dialog and proper authorization. Non-authors do not see the delete button. ([nextjs/src/app/chapter/[abbrev]/[chapter]/ChapterClient.tsxR1164-R1183](diffhunk://#diff-614f67988c8a8af93d2320b2cb202590fe30e44ff8d17ce7f8244c946d29a51cR1164-R1183), [nextjs/cypress/e2e/comments.cy.tsR278-R321](diffhunk://#diff-df9054fc51b75ce17c3caf2fde01abc0baf98c50931abeb27bd8fe3f9e74a070R278-R321))

**End-to-End and Integration Testing:**

* Adds comprehensive Cypress tests for multi-category badge rendering, share-as-image functionality, and inline comment deletion, ensuring feature coverage and correct permissions. [[1]](diffhunk://#diff-d5282c932b9696eedba0ed89017678532ee6758ccb218e98c0e4341487c4915dR1-R101) [[2]](diffhunk://#diff-df9054fc51b75ce17c3caf2fde01abc0baf98c50931abeb27bd8fe3f9e74a070R278-R321)