### PR TITLE
Post-ship cleanup: de-flake verify-email, patch vite/ws CVEs, DeepSource lint

### DIFF
--- a/nextjs/cypress/e2e/pwa-manifest.cy.ts
+++ b/nextjs/cypress/e2e/pwa-manifest.cy.ts
@@ -16,6 +16,9 @@ describe("PWA manifest + share_target prefill", () => {
 			expect(m.share_target.action).to.eq("/search");
 			expect(m.share_target.params).to.deep.eq({ text: "q" });
 			expect(m.launch_handler.client_mode).to.include("navigate-existing");
+			// Task E: install prompts prefer the published Play app.
+			expect(m.prefer_related_applications).to.eq(true);
+			expect(m.related_applications[0].id).to.eq("br.com.biblecomment.app");
 		});
 	});
 

--- a/nextjs/cypress/e2e/verify-email.cy.ts
+++ b/nextjs/cypress/e2e/verify-email.cy.ts
@@ -112,16 +112,13 @@ describe("Email verification", () => {
 			const verse = (
 				res.body as Array<{ _id: string; verseNumber: number }>
 			).find((v) => v.verseNumber === 1);
-			expect(verse, "verse Gn 1:1 should be seeded").to.exist;
+			if (!verse) throw new Error("verse Gn 1:1 should be seeded");
 
 			cy.request({
 				method: "POST",
-				url: `/api/comments/${verse!._id}`,
+				url: `/api/comments/${verse._id}`,
 				body: {
-					text:
-						"Comentário tentando ser publicado sem verificação. " +
-						"Texto longo o suficiente para satisfazer o limite mínimo " +
-						"de duzentos caracteres exigidos pelo sistema. ".repeat(2),
+					text: `Comentário tentando ser publicado sem verificação. Texto longo o suficiente para satisfazer o limite mínimo ${"de duzentos caracteres exigidos pelo sistema. ".repeat(2)}`,
 					tags: ["devocional"],
 				},
 				failOnStatusCode: false,
@@ -179,16 +176,13 @@ describe("Email verification", () => {
 			const verse = (
 				res.body as Array<{ _id: string; verseNumber: number }>
 			).find((v) => v.verseNumber === 1);
-			expect(verse).to.exist;
+			if (!verse) throw new Error("verse Gn 1:1 should be seeded");
 
 			cy.request({
 				method: "POST",
-				url: `/api/comments/${verse!._id}`,
+				url: `/api/comments/${verse._id}`,
 				body: {
-					text:
-						"Comentário publicado após a verificação do e-mail. " +
-						"Texto longo o suficiente para satisfazer o limite mínimo " +
-						"de duzentos caracteres exigidos pelo sistema. ".repeat(2),
+					text: `Comentário publicado após a verificação do e-mail. Texto longo o suficiente para satisfazer o limite mínimo ${"de duzentos caracteres exigidos pelo sistema. ".repeat(2)}`,
 					tags: ["devocional"],
 				},
 			}).then((createRes) => {

--- a/nextjs/cypress/e2e/verify-email.cy.ts
+++ b/nextjs/cypress/e2e/verify-email.cy.ts
@@ -19,235 +19,245 @@
 import bookFixture from "../fixtures/book-gn.json";
 
 interface MemoryEmail {
-  to: string;
-  subject: string;
-  html: string;
-  text: string;
+	to: string;
+	subject: string;
+	html: string;
+	text: string;
 }
 
 function fetchLatestVerificationEmail(
-  toEmail: string,
-  attemptsLeft = 10,
+	toEmail: string,
+	attemptsLeft = 10,
 ): Cypress.Chainable<MemoryEmail> {
-  return cy
-    .request<{ messages: MemoryEmail[] }>("/api/dev/last-email")
-    .then((res) => {
-      const inbox = (res.body.messages ?? []) as MemoryEmail[];
-      const found = [...inbox]
-        .reverse()
-        .find(
-          (msg) =>
-            msg.to.toLowerCase() === toEmail.toLowerCase() &&
-            /confirme|verif/i.test(msg.subject),
-        );
-      if (found) return cy.wrap(found);
-      if (attemptsLeft <= 0) {
-        throw new Error(
-          `No verification email for ${toEmail} after polling (inbox has ${inbox.length} message(s))`,
-        );
-      }
-      // The send action is fire-and-forget — the email may not have been
-      // written to the dev inbox yet. Wait briefly and poll again instead of
-      // failing on the first empty read (the race that flaked this spec).
-      return cy
-        .wait(300)
-        .then(() => fetchLatestVerificationEmail(toEmail, attemptsLeft - 1));
-    });
+	return cy
+		.request<{ messages: MemoryEmail[] }>("/api/dev/last-email")
+		.then((res) => {
+			const inbox = (res.body.messages ?? []) as MemoryEmail[];
+			const found = [...inbox]
+				.reverse()
+				.find(
+					(msg) =>
+						msg.to.toLowerCase() === toEmail.toLowerCase() &&
+						/confirme|verif/i.test(msg.subject),
+				);
+			if (found) return cy.wrap(found);
+			if (attemptsLeft <= 0) {
+				throw new Error(
+					`No verification email for ${toEmail} after polling (inbox has ${inbox.length} message(s))`,
+				);
+			}
+			// The send action is fire-and-forget — the email may not have been
+			// written to the dev inbox yet. Wait briefly and poll again instead of
+			// failing on the first empty read (the race that flaked this spec).
+			return cy
+				.wait(300)
+				.then(() => fetchLatestVerificationEmail(toEmail, attemptsLeft - 1));
+		});
 }
 
 function extractToken(text: string): string {
-  const match = text.match(/\/verify-email\?token=([\w-]+)/);
-  if (!match) {
-    throw new Error(`No /verify-email?token= link in body:\n${text}`);
-  }
-  return match[1];
+	const match = text.match(/\/verify-email\?token=([\w-]+)/);
+	if (!match) {
+		throw new Error(`No /verify-email?token= link in body:\n${text}`);
+	}
+	return match[1];
 }
 
 function clearInbox(): Cypress.Chainable<unknown> {
-  return cy.request({
-    method: "DELETE",
-    url: "/api/dev/last-email",
-    failOnStatusCode: false,
-  });
+	return cy.request({
+		method: "DELETE",
+		url: "/api/dev/last-email",
+		failOnStatusCode: false,
+	});
 }
 
 describe("Email verification", () => {
-  const seed = Math.random().toString(36).slice(2, 8);
-  const username = `verify_${seed}`;
-  const email1 = `verify_${seed}@cypress.test`;
-  const email2 = `verify2_${seed}@cypress.test`;
-  const password = "verify-secret-123";
+	const seed = Math.random().toString(36).slice(2, 8);
+	const username = `verify_${seed}`;
+	const email1 = `verify_${seed}@cypress.test`;
+	const email2 = `verify2_${seed}@cypress.test`;
+	const password = "verify-secret-123";
 
-  beforeEach(() => {
-    cy.resetDb();
-    cy.seedDb({
-      users: [
-        {
-          email: email1,
-          username,
-          password,
-          // The whole point of this spec is to drive the unverified-user flow.
-          emailVerified: false,
-          tutorialsCompleted: ["chapter-v1", "home-v1", "communities-v1", "discussions-v1", "profile-v1"],
-        },
-      ],
-      books: [bookFixture.book],
-      verses: bookFixture.verses,
-    });
-    clearInbox();
-  });
+	beforeEach(() => {
+		cy.resetDb();
+		cy.seedDb({
+			users: [
+				{
+					email: email1,
+					username,
+					password,
+					// The whole point of this spec is to drive the unverified-user flow.
+					emailVerified: false,
+					tutorialsCompleted: [
+						"chapter-v1",
+						"home-v1",
+						"communities-v1",
+						"discussions-v1",
+						"profile-v1",
+					],
+				},
+			],
+			books: [bookFixture.book],
+			verses: bookFixture.verses,
+		});
+		clearInbox();
+	});
 
-  // ─────────────────────────────────────────────────────────────────────────
-  it("blocks comment creation while unverified", () => {
-    cy.loginAs(email1, password);
+	// ─────────────────────────────────────────────────────────────────────────
+	it("blocks comment creation while unverified", () => {
+		cy.loginAs(email1, password);
 
-    // The verse id is needed to POST a comment; resolve via the public API.
-    cy.request("GET", "/api/books/gn/verses/1").then((res) => {
-      const verse = (res.body as Array<{ _id: string; verseNumber: number }>)
-        .find((v) => v.verseNumber === 1);
-      expect(verse, "verse Gn 1:1 should be seeded").to.exist;
+		// The verse id is needed to POST a comment; resolve via the public API.
+		cy.request("GET", "/api/books/gn/verses/1").then((res) => {
+			const verse = (
+				res.body as Array<{ _id: string; verseNumber: number }>
+			).find((v) => v.verseNumber === 1);
+			expect(verse, "verse Gn 1:1 should be seeded").to.exist;
 
-      cy.request({
-        method: "POST",
-        url: `/api/comments/${verse!._id}`,
-        body: {
-          text:
-            "Comentário tentando ser publicado sem verificação. " +
-            "Texto longo o suficiente para satisfazer o limite mínimo " +
-            "de duzentos caracteres exigidos pelo sistema. ".repeat(2),
-          tags: ["devocional"],
-        },
-        failOnStatusCode: false,
-      }).then((createRes) => {
-        expect(createRes.status).to.be.oneOf([400, 401, 403, 422]);
-        // The exact wording comes from EmailNotVerifiedError's default message.
-        expect(JSON.stringify(createRes.body)).to.match(/verifique seu e-?mail/i);
-      });
-    });
-  });
+			cy.request({
+				method: "POST",
+				url: `/api/comments/${verse!._id}`,
+				body: {
+					text:
+						"Comentário tentando ser publicado sem verificação. " +
+						"Texto longo o suficiente para satisfazer o limite mínimo " +
+						"de duzentos caracteres exigidos pelo sistema. ".repeat(2),
+					tags: ["devocional"],
+				},
+				failOnStatusCode: false,
+			}).then((createRes) => {
+				expect(createRes.status).to.be.oneOf([400, 401, 403, 422]);
+				// The exact wording comes from EmailNotVerifiedError's default message.
+				expect(JSON.stringify(createRes.body)).to.match(
+					/verifique seu e-?mail/i,
+				);
+			});
+		});
+	});
 
-  // ─────────────────────────────────────────────────────────────────────────
-  it("global banner is visible on /home for unverified users", () => {
-    cy.loginAs(email1, password);
-    cy.visit("/home");
-    cy.get('[data-testid="email-verification-banner"]').should("be.visible");
-  });
+	// ─────────────────────────────────────────────────────────────────────────
+	it("global banner is visible on /home for unverified users", () => {
+		cy.loginAs(email1, password);
+		cy.visit("/home");
+		cy.get('[data-testid="email-verification-banner"]').should("be.visible");
+	});
 
-  // ─────────────────────────────────────────────────────────────────────────
-  it("profile config card shows 'Não verificado' and triggers send", () => {
-    cy.loginAs(email1, password);
-    cy.visit("/profile?tab=config");
-    cy.get('[data-testid="email-verification-card"]').should("exist");
-    cy.get('[data-testid="email-verification-state-unverified"]').should(
-      "be.visible",
-    );
+	// ─────────────────────────────────────────────────────────────────────────
+	it("profile config card shows 'Não verificado' and triggers send", () => {
+		cy.loginAs(email1, password);
+		cy.visit("/profile?tab=config");
+		cy.get('[data-testid="email-verification-card"]').should("exist");
+		cy.get('[data-testid="email-verification-state-unverified"]').should(
+			"be.visible",
+		);
 
-    // Trigger the send and confirm an email lands in the in-memory inbox.
-    cy.get('[data-testid="email-verification-send"]').click();
-    fetchLatestVerificationEmail(email1).then((mail) => {
-      expect(mail.text).to.match(/verify-email\?token=/);
-    });
-  });
+		// Trigger the send and confirm an email lands in the in-memory inbox.
+		cy.get('[data-testid="email-verification-send"]').click();
+		fetchLatestVerificationEmail(email1).then((mail) => {
+			expect(mail.text).to.match(/verify-email\?token=/);
+		});
+	});
 
-  // ─────────────────────────────────────────────────────────────────────────
-  it("verifying via the magic link unlocks commenting + shows the badge", () => {
-    cy.loginAs(email1, password);
+	// ─────────────────────────────────────────────────────────────────────────
+	it("verifying via the magic link unlocks commenting + shows the badge", () => {
+		cy.loginAs(email1, password);
 
-    // Trigger the send from /profile.
-    cy.visit("/profile?tab=config");
-    cy.get('[data-testid="email-verification-send"]').click();
+		// Trigger the send from /profile.
+		cy.visit("/profile?tab=config");
+		cy.get('[data-testid="email-verification-send"]').click();
 
-    // Follow the link in the email.
-    fetchLatestVerificationEmail(email1).then((mail) => {
-      const token = extractToken(mail.text);
-      cy.visit(`/verify-email?token=${token}`);
-      cy.get('[data-testid="verify-email-confirm"]').click();
-      cy.get('[data-testid="verify-email-success"]').should("be.visible");
-    });
+		// Follow the link in the email.
+		fetchLatestVerificationEmail(email1).then((mail) => {
+			const token = extractToken(mail.text);
+			cy.visit(`/verify-email?token=${token}`);
+			cy.get('[data-testid="verify-email-confirm"]').click();
+			cy.get('[data-testid="verify-email-success"]').should("be.visible");
+		});
 
-    // Now the API accepts a new comment.
-    cy.request("GET", "/api/books/gn/verses/1").then((res) => {
-      const verse = (res.body as Array<{ _id: string; verseNumber: number }>)
-        .find((v) => v.verseNumber === 1);
-      expect(verse).to.exist;
+		// Now the API accepts a new comment.
+		cy.request("GET", "/api/books/gn/verses/1").then((res) => {
+			const verse = (
+				res.body as Array<{ _id: string; verseNumber: number }>
+			).find((v) => v.verseNumber === 1);
+			expect(verse).to.exist;
 
-      cy.request({
-        method: "POST",
-        url: `/api/comments/${verse!._id}`,
-        body: {
-          text:
-            "Comentário publicado após a verificação do e-mail. " +
-            "Texto longo o suficiente para satisfazer o limite mínimo " +
-            "de duzentos caracteres exigidos pelo sistema. ".repeat(2),
-          tags: ["devocional"],
-        },
-      }).then((createRes) => {
-        expect(createRes.status).to.eq(201);
-      });
-    });
+			cy.request({
+				method: "POST",
+				url: `/api/comments/${verse!._id}`,
+				body: {
+					text:
+						"Comentário publicado após a verificação do e-mail. " +
+						"Texto longo o suficiente para satisfazer o limite mínimo " +
+						"de duzentos caracteres exigidos pelo sistema. ".repeat(2),
+					tags: ["devocional"],
+				},
+			}).then((createRes) => {
+				expect(createRes.status).to.eq(201);
+			});
+		});
 
-    // Public profile shows the verified badge in the header.
-    cy.visit(`/u/${username}`);
-    cy
-      .get('[data-testid="public-profile-header"]')
-      .find('[data-testid="verified-badge"]')
-      .should("exist");
-  });
+		// Public profile shows the verified badge in the header.
+		cy.visit(`/u/${username}`);
+		cy.get('[data-testid="public-profile-header"]')
+			.find('[data-testid="verified-badge"]')
+			.should("exist");
+	});
 
-  // ─────────────────────────────────────────────────────────────────────────
-  it(
-    "email change: pending state, mail goes to NEW address, badge persists after confirm",
-    () => {
-      // Pre-verify the user so we exercise the change-from-verified path.
-      // (The seedDb default would also work, but we override here to be
-      // explicit about the starting state of this scenario.)
-      cy.resetDb();
-      cy.seedDb({
-        users: [
-          {
-            email: email1,
-            username,
-            password,
-            emailVerified: true,
-            tutorialsCompleted: ["chapter-v1", "home-v1", "communities-v1", "discussions-v1", "profile-v1"],
-          },
-        ],
-        books: [bookFixture.book],
-        verses: bookFixture.verses,
-      });
-      clearInbox();
+	// ─────────────────────────────────────────────────────────────────────────
+	it("email change: pending state, mail goes to NEW address, badge persists after confirm", () => {
+		// Pre-verify the user so we exercise the change-from-verified path.
+		// (The seedDb default would also work, but we override here to be
+		// explicit about the starting state of this scenario.)
+		cy.resetDb();
+		cy.seedDb({
+			users: [
+				{
+					email: email1,
+					username,
+					password,
+					emailVerified: true,
+					tutorialsCompleted: [
+						"chapter-v1",
+						"home-v1",
+						"communities-v1",
+						"discussions-v1",
+						"profile-v1",
+					],
+				},
+			],
+			books: [bookFixture.book],
+			verses: bookFixture.verses,
+		});
+		clearInbox();
 
-      cy.loginAs(email1, password);
-      cy.visit("/profile?tab=config");
-      cy.get('[data-testid="email-verification-new-email"]')
-        .clear()
-        .type(email2);
-      cy.get('[data-testid="email-verification-change-submit"]').click();
-      cy.get('[data-testid="email-verification-pending"]').should(
-        "contain",
-        email2,
-      );
+		cy.loginAs(email1, password);
+		cy.visit("/profile?tab=config");
+		cy.get('[data-testid="email-verification-new-email"]').clear().type(email2);
+		cy.get('[data-testid="email-verification-change-submit"]').click();
+		cy.get('[data-testid="email-verification-pending"]').should(
+			"contain",
+			email2,
+		);
 
-      // The verification email MUST be sent to the NEW address.
-      fetchLatestVerificationEmail(email2).then((mail) => {
-        const token = extractToken(mail.text);
-        cy.visit(`/verify-email?token=${token}`);
-        cy.get('[data-testid="verify-email-confirm"]').click();
-        cy.get('[data-testid="verify-email-success"]').should("be.visible");
-      });
+		// The verification email MUST be sent to the NEW address.
+		fetchLatestVerificationEmail(email2).then((mail) => {
+			const token = extractToken(mail.text);
+			cy.visit(`/verify-email?token=${token}`);
+			cy.get('[data-testid="verify-email-confirm"]').click();
+			cy.get('[data-testid="verify-email-success"]').should("be.visible");
+		});
 
-      // After email-change confirmation the user's primary email in the DB is
-      // now email2. Re-login so the session JWT carries the new email before
-      // we visit /profile — otherwise /api/users/me would query by email1 and
-      // return 401.
-      cy.loginAs(email2, password);
-      cy.visit("/profile?tab=config");
-      // Longer timeout: under the full-suite CI load the verified badge can
-      // take >4s to paint, which flaked this assertion.
-      cy.get('[data-testid="email-verification-state-verified"]', {
-        timeout: 10000,
-      }).should("be.visible");
-      cy.contains(email2);
-    },
-  );
+		// After email-change confirmation the user's primary email in the DB is
+		// now email2. Re-login so the session JWT carries the new email before
+		// we visit /profile — otherwise /api/users/me would query by email1 and
+		// return 401.
+		cy.loginAs(email2, password);
+		cy.visit("/profile?tab=config");
+		// Longer timeout: under the full-suite CI load the verified badge can
+		// take >4s to paint, which flaked this assertion.
+		cy.get('[data-testid="email-verification-state-verified"]', {
+			timeout: 10000,
+		}).should("be.visible");
+		cy.contains(email2);
+	});
 });

--- a/nextjs/cypress/e2e/verify-email.cy.ts
+++ b/nextjs/cypress/e2e/verify-email.cy.ts
@@ -27,6 +27,7 @@ interface MemoryEmail {
 
 function fetchLatestVerificationEmail(
   toEmail: string,
+  attemptsLeft = 10,
 ): Cypress.Chainable<MemoryEmail> {
   return cy
     .request<{ messages: MemoryEmail[] }>("/api/dev/last-email")
@@ -35,16 +36,22 @@ function fetchLatestVerificationEmail(
       const found = [...inbox]
         .reverse()
         .find(
-          (m) =>
-            m.to.toLowerCase() === toEmail.toLowerCase() &&
-            /confirme|verif/i.test(m.subject),
+          (msg) =>
+            msg.to.toLowerCase() === toEmail.toLowerCase() &&
+            /confirme|verif/i.test(msg.subject),
         );
-      if (!found) {
+      if (found) return cy.wrap(found);
+      if (attemptsLeft <= 0) {
         throw new Error(
-          `No verification email for ${toEmail} (inbox has ${inbox.length} message(s))`,
+          `No verification email for ${toEmail} after polling (inbox has ${inbox.length} message(s))`,
         );
       }
-      return cy.wrap(found);
+      // The send action is fire-and-forget — the email may not have been
+      // written to the dev inbox yet. Wait briefly and poll again instead of
+      // failing on the first empty read (the race that flaked this spec).
+      return cy
+        .wait(300)
+        .then(() => fetchLatestVerificationEmail(toEmail, attemptsLeft - 1));
     });
 }
 
@@ -235,9 +242,11 @@ describe("Email verification", () => {
       // return 401.
       cy.loginAs(email2, password);
       cy.visit("/profile?tab=config");
-      cy.get('[data-testid="email-verification-state-verified"]').should(
-        "be.visible",
-      );
+      // Longer timeout: under the full-suite CI load the verified badge can
+      // take >4s to paint, which flaked this assertion.
+      cy.get('[data-testid="email-verification-state-verified"]', {
+        timeout: 10000,
+      }).should("be.visible");
       cy.contains(email2);
     },
   );

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -2078,9 +2078,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2311,9 +2311,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -2328,9 +2328,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -2345,9 +2345,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -2362,9 +2362,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -2396,9 +2396,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -2430,9 +2430,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2464,9 +2464,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2481,9 +2481,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2498,9 +2498,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2515,9 +2515,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2534,9 +2534,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2551,9 +2551,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2568,9 +2568,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11572,9 +11572,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -12546,9 +12546,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -12565,7 +12565,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12881,28 +12881,6 @@
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -13261,14 +13239,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -13277,21 +13255,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rollup": {
@@ -14543,9 +14521,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15100,17 +15078,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -15126,7 +15104,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -15661,17 +15639,17 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -69,6 +69,8 @@
   "overrides": {
     "fast-uri": "^3.1.2",
     "follow-redirects": "^1.16.0",
+    "vite": "^8.0.16",
+    "ws": "^8.21.0",
     "next": {
       "postcss": "^8.5.14"
     },

--- a/nextjs/public/manifest.webmanifest
+++ b/nextjs/public/manifest.webmanifest
@@ -91,5 +91,13 @@
       "url": "/communities",
       "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" }]
     }
-  ]
+  ],
+  "related_applications": [
+    {
+      "platform": "play",
+      "url": "https://play.google.com/store/apps/details?id=br.com.biblecomment.app",
+      "id": "br.com.biblecomment.app"
+    }
+  ],
+  "prefer_related_applications": true
 }

--- a/nextjs/src/app/discussions/DiscussionsClient.tsx
+++ b/nextjs/src/app/discussions/DiscussionsClient.tsx
@@ -122,6 +122,7 @@ export default function DiscussionsClient({
 					/>
 					<select
 						data-testid="discussions-book-filter"
+						aria-label="Filtrar por livro"
 						value={bookAbbrev}
 						onChange={(e) => {
 							// Updating bookAbbrev triggers the [sort, bookAbbrev]
@@ -172,7 +173,7 @@ export default function DiscussionsClient({
 					{loading && discussions.length === 0 ? (
 						<Loading />
 					) : discussions.length === 0 ? (
-						<div className="text-center text-gray-400 dark:text-slate-500 py-10">
+						<div className="text-center text-gray-500 dark:text-slate-400 py-10">
 							Nenhuma discussão encontrada.
 						</div>
 					) : (

--- a/nextjs/src/app/leitura-offline/parseChapterPath.ts
+++ b/nextjs/src/app/leitura-offline/parseChapterPath.ts
@@ -10,9 +10,9 @@
 export function parseChapterPath(
   pathname: string,
 ): { abbrev: string; chapter: number } | null {
-  const m = pathname.match(/^\/verses\/([^/]+)\/(\d+)\/?$/);
-  if (!m) return null;
-  const chapter = parseInt(m[2], 10);
+  const match = pathname.match(/^\/verses\/([^/]+)\/(\d+)\/?$/);
+  if (!match) return null;
+  const chapter = parseInt(match[2], 10);
   if (Number.isNaN(chapter)) return null;
-  return { abbrev: m[1], chapter };
+  return { abbrev: match[1], chapter };
 }

--- a/nextjs/src/app/leitura-offline/parseChapterPath.ts
+++ b/nextjs/src/app/leitura-offline/parseChapterPath.ts
@@ -8,11 +8,11 @@
 // /verses/:abbrev/:number navigation while keeping the address bar on the real
 // chapter URL, so the shell reads its target from location.pathname.
 export function parseChapterPath(
-  pathname: string,
+	pathname: string,
 ): { abbrev: string; chapter: number } | null {
-  const match = pathname.match(/^\/verses\/([^/]+)\/(\d+)\/?$/);
-  if (!match) return null;
-  const chapter = parseInt(match[2], 10);
-  if (Number.isNaN(chapter)) return null;
-  return { abbrev: match[1], chapter };
+	const match = pathname.match(/^\/verses\/([^/]+)\/(\d+)\/?$/);
+	if (!match) return null;
+	const chapter = parseInt(match[2], 10);
+	if (Number.isNaN(chapter)) return null;
+	return { abbrev: match[1], chapter };
 }

--- a/nextjs/src/app/profile/ProfileClient.tsx
+++ b/nextjs/src/app/profile/ProfileClient.tsx
@@ -344,7 +344,10 @@ function EmailVerificationCard({
 		try {
 			const mod = await import("@/app/actions/email-verification");
 			await mod.requestEmailVerificationAction();
-			handleNotification("success", `Enviamos um link para ${pendingEmail ?? currentEmail}.`);
+			handleNotification(
+				"success",
+				`Enviamos um link para ${pendingEmail ?? currentEmail}.`,
+			);
 		} catch {
 			handleNotification("error", "Erro ao enviar verificação.");
 		} finally {
@@ -359,7 +362,10 @@ function EmailVerificationCard({
 			const mod = await import("@/app/actions/email-verification");
 			const res = await mod.requestEmailChangeAction(newEmail.trim());
 			if (res.ok) {
-				handleNotification("success", `Enviamos um link de confirmação para ${newEmail.trim()}.`);
+				handleNotification(
+					"success",
+					`Enviamos um link de confirmação para ${newEmail.trim()}.`,
+				);
 				setNewEmail("");
 				onChanged();
 				await updateSession({ pendingEmail: newEmail.trim() });
@@ -396,7 +402,9 @@ function EmailVerificationCard({
 			</div>
 
 			<div className="flex flex-wrap items-center gap-2 text-[13px] mb-4">
-				<span className="text-slate-800 dark:text-slate-100">{currentEmail}</span>
+				<span className="text-slate-800 dark:text-slate-100">
+					{currentEmail}
+				</span>
 				{emailVerified ? (
 					<span
 						data-testid="email-verification-state-verified"
@@ -456,7 +464,10 @@ function EmailVerificationCard({
 			) : null}
 
 			<div className="border-t border-slate-100 dark:border-slate-800 pt-4">
-				<label htmlFor="profile-new-email" className="block text-[13px] font-semibold mb-1.5 text-slate-800 dark:text-slate-100">
+				<label
+					htmlFor="profile-new-email"
+					className="block text-[13px] font-semibold mb-1.5 text-slate-800 dark:text-slate-100"
+				>
 					Trocar e-mail
 				</label>
 				<div className="flex gap-2">
@@ -1080,7 +1091,10 @@ function OfflineBibleCard() {
 			<div className="font-bold text-sm text-slate-800 dark:text-slate-100 mb-4">
 				Leitura offline
 			</div>
-			<div className="flex items-start gap-3.5" data-testid="offline-bible-toggle">
+			<div
+				className="flex items-start gap-3.5"
+				data-testid="offline-bible-toggle"
+			>
 				<Toggle
 					checked={enabled}
 					onChange={onToggle}
@@ -1109,7 +1123,13 @@ function OfflineBibleCard() {
 }
 
 /* ──────────────────────── Main component ──────────────────────── */
-const VALID_TABS: Tab[] = ["overview", "comments", "favorites", "badges", "config"];
+const VALID_TABS: Tab[] = [
+	"overview",
+	"comments",
+	"favorites",
+	"badges",
+	"config",
+];
 
 export default function ProfileClient({
 	user,
@@ -1167,7 +1187,9 @@ export default function ProfileClient({
 		if (!profile) return;
 		if (searchParams.get("verify") !== "1") return;
 		if (profile.emailVerified && !profile.pendingEmail) return;
-		import("@/app/actions/email-verification").then((mod) => mod.requestEmailVerificationAction());
+		import("@/app/actions/email-verification").then((mod) =>
+			mod.requestEmailVerificationAction(),
+		);
 	}, [profile, searchParams]);
 
 	/* ── Data loaders ── */
@@ -1719,10 +1741,7 @@ export default function ProfileClient({
 									className="flex items-start gap-3.5 pb-4"
 									data-testid="show-belief-toggle"
 								>
-									<Toggle
-										checked={showReligion}
-										onChange={setShowReligion}
-									/>
+									<Toggle checked={showReligion} onChange={setShowReligion} />
 									<div>
 										<div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 leading-[19.5px]">
 											Mostrar minha religião no perfil público
@@ -1739,10 +1758,7 @@ export default function ProfileClient({
 
 								{/* Toggle 2 */}
 								<div className="flex items-start gap-3.5">
-									<Toggle
-										checked={showHistory}
-										onChange={setShowHistory}
-									/>
+									<Toggle checked={showHistory} onChange={setShowHistory} />
 									<div>
 										<div className="font-semibold text-[13px] text-slate-800 dark:text-slate-100 leading-[19.5px]">
 											Permitir que outros vejam meu histórico de comentários

--- a/nextjs/src/app/profile/ProfileClient.tsx
+++ b/nextjs/src/app/profile/ProfileClient.tsx
@@ -32,7 +32,7 @@ import {
 import { syncOfflineBible } from "@/lib/offline/bibleSync";
 import { getMeta, clearStore, type SyncStatus } from "@/lib/offline/bibleStore";
 
-const { beliefs, states } = collectionsData as {
+const { beliefs } = collectionsData as {
 	beliefs: string[];
 	states: string[];
 };
@@ -1045,7 +1045,7 @@ function OfflineBibleCard() {
 	useEffect(() => {
 		setEnabled(isOfflineBibleEnabled());
 		getMeta()
-			.then((m) => setStatus(m?.status ?? null))
+			.then((meta) => setStatus(meta?.status ?? null))
 			.catch(() => setStatus(null));
 	}, []);
 
@@ -1060,8 +1060,8 @@ function OfflineBibleCard() {
 				handleNotification("info", "Baixando a Bíblia para uso offline…");
 				try {
 					await syncOfflineBible({ enabled: true });
-					const m = await getMeta();
-					setStatus(m?.status ?? "ready");
+					const meta = await getMeta();
+					setStatus(meta?.status ?? "ready");
 				} catch {
 					// syncOfflineBible never rejects; guard for safety.
 				}

--- a/nextjs/src/components/ChapterReader/ChapterReader.tsx
+++ b/nextjs/src/components/ChapterReader/ChapterReader.tsx
@@ -43,7 +43,7 @@ export function ChapterReader({
           // Guard on a real _id: offline verses have none, and without this
           // `undefined === undefined` would mark every verse "selected".
           const isSelected =
-            !!verse._id && selectedVerse?._id === verse._id && !isTitleMode;
+            Boolean(verse._id) && selectedVerse?._id === verse._id && !isTitleMode;
           return (
             <li
               key={verse._id ?? `${verse.verseNumber}`}

--- a/nextjs/src/components/ChapterReader/ChapterReader.tsx
+++ b/nextjs/src/components/ChapterReader/ChapterReader.tsx
@@ -4,18 +4,18 @@ import { Verse } from "@/domain/entities/Verse";
 import { CopyVerseButton } from "@/components/CopyVerseButton";
 
 interface ChapterReaderProps {
-  abbrev: string;
-  chapter: number;
-  verses: Verse[];
-  // Per-verse comment counts by verse _id. Empty in the offline shell.
-  countMap?: Record<string, number>;
-  // Currently-open verse (drives the highlight). Null in the offline shell.
-  selectedVerse?: Verse | null;
-  // Whether the title/overview panel is open (suppresses verse highlight).
-  isTitleMode?: boolean;
-  // Tapping a verse opens its comment panel. Omitted offline → verses are
-  // plain (no panel) but still copyable.
-  onSelectVerse?: (verse: Verse) => void;
+	abbrev: string;
+	chapter: number;
+	verses: Verse[];
+	// Per-verse comment counts by verse _id. Empty in the offline shell.
+	countMap?: Record<string, number>;
+	// Currently-open verse (drives the highlight). Null in the offline shell.
+	selectedVerse?: Verse | null;
+	// Whether the title/overview panel is open (suppresses verse highlight).
+	isTitleMode?: boolean;
+	// Tapping a verse opens its comment panel. Omitted offline → verses are
+	// plain (no panel) but still copyable.
+	onSelectVerse?: (verse: Verse) => void;
 }
 
 // Presentational verse column shared by the online ChapterClient and the
@@ -23,114 +23,116 @@ interface ChapterReaderProps {
 // caller simply omits the comment-related props (countMap/selection/onSelect),
 // so there are no badges and tapping a verse does nothing but copy.
 export function ChapterReader({
-  abbrev,
-  chapter,
-  verses,
-  countMap = {},
-  selectedVerse = null,
-  isTitleMode = false,
-  onSelectVerse,
+	abbrev,
+	chapter,
+	verses,
+	countMap = {},
+	selectedVerse = null,
+	isTitleMode = false,
+	onSelectVerse,
 }: ChapterReaderProps) {
-  return (
-    <div className="relative">
-      <div className="hidden md:block absolute right-full top-0 -mr-5 z-10 text-right font-serif select-none pointer-events-none text-[80px] leading-[80px] font-black text-slate-800 dark:text-slate-100 opacity-80">
-        {chapter}
-      </div>
+	return (
+		<div className="relative">
+			<div className="hidden md:block absolute right-full top-0 -mr-5 z-10 text-right font-serif select-none pointer-events-none text-[80px] leading-[80px] font-black text-slate-800 dark:text-slate-100 opacity-80">
+				{chapter}
+			</div>
 
-      <ul className="space-y-[2px]">
-        {verses.map((verse, idx) => {
-          const count = verse._id ? (countMap[verse._id] ?? 0) : 0;
-          // Guard on a real _id: offline verses have none, and without this
-          // `undefined === undefined` would mark every verse "selected".
-          const isSelected =
-            Boolean(verse._id) && selectedVerse?._id === verse._id && !isTitleMode;
-          return (
-            <li
-              key={verse._id ?? `${verse.verseNumber}`}
-              id={String(verse.verseNumber)}
-              data-tour={idx === 0 ? "verse-first" : undefined}
-              className="group relative"
-            >
-              <button
-                type="button"
-                onClick={() => onSelectVerse?.(verse)}
-                className={`flex items-start gap-2 md:gap-3 w-full text-left rounded-r-[4px] transition border-l-4 border-solid pt-3 pr-2.5 pl-1.5 md:pl-3 md:pt-2 md:pb-2 hover:bg-[rgba(19,125,219,0.07)] dark:hover:bg-[rgba(19,125,219,0.16)] active:bg-[rgba(19,125,219,0.12)] dark:active:bg-[rgba(19,125,219,0.22)] min-h-[44px] ${count > 0 ? "pb-7 md:pb-2" : "pb-3"}`}
-                style={{
-                  borderLeftColor: isSelected ? "#137ddb" : "transparent",
-                  background: isSelected ? "rgba(19,125,219,0.04)" : undefined,
-                }}
-              >
-                <span
-                  className="font-sans font-bold text-[14px] md:text-[13px] w-5 md:w-5 flex-shrink-0 text-right mt-[2px] transition"
-                  style={{ color: isSelected ? "#137ddb" : "#94a3b8" }}
-                >
-                  {verse.verseNumber}
-                </span>
-                <span
-                  data-testid="verse-text"
-                  className="flex-1 font-serif leading-[1.85] transition text-[#1a1a1a] dark:text-slate-100"
-                  style={{ fontSize: "17px" }}
-                >
-                  {verse.text}
-                </span>
-                {count > 0 && (
-                  <span className="hidden md:flex flex-shrink-0 items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand">
-                    <svg
-                      width="9"
-                      height="9"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="#fff"
-                      strokeWidth="2.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                    </svg>
-                    <span className="font-bold text-[11px] text-white leading-[11px]">
-                      {count}
-                    </span>
-                  </span>
-                )}
-              </button>
-              {count > 0 && (
-                <span
-                  aria-hidden="true"
-                  className="md:hidden absolute right-2 bottom-1.5 flex items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand pointer-events-none"
-                >
-                  <svg
-                    width="9"
-                    height="9"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="#fff"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                  </svg>
-                  <span className="font-bold text-[11px] text-white leading-[11px]">
-                    {count}
-                  </span>
-                </span>
-              )}
-              <div className="absolute right-[-10px] top-1 rounded-md bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm md:opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity opacity-60">
-                <CopyVerseButton
-                  verse={{
-                    abbrev,
-                    chapter,
-                    verseNumber: verse.verseNumber,
-                    text: verse.text,
-                  }}
-                  label=""
-                  className="!px-1.5 !py-1"
-                />
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
+			<ul className="space-y-[2px]">
+				{verses.map((verse, idx) => {
+					const count = verse._id ? (countMap[verse._id] ?? 0) : 0;
+					// Guard on a real _id: offline verses have none, and without this
+					// `undefined === undefined` would mark every verse "selected".
+					const isSelected =
+						Boolean(verse._id) &&
+						selectedVerse?._id === verse._id &&
+						!isTitleMode;
+					return (
+						<li
+							key={verse._id ?? `${verse.verseNumber}`}
+							id={String(verse.verseNumber)}
+							data-tour={idx === 0 ? "verse-first" : undefined}
+							className="group relative"
+						>
+							<button
+								type="button"
+								onClick={() => onSelectVerse?.(verse)}
+								className={`flex items-start gap-2 md:gap-3 w-full text-left rounded-r-[4px] transition border-l-4 border-solid pt-3 pr-2.5 pl-1.5 md:pl-3 md:pt-2 md:pb-2 hover:bg-[rgba(19,125,219,0.07)] dark:hover:bg-[rgba(19,125,219,0.16)] active:bg-[rgba(19,125,219,0.12)] dark:active:bg-[rgba(19,125,219,0.22)] min-h-[44px] ${count > 0 ? "pb-7 md:pb-2" : "pb-3"}`}
+								style={{
+									borderLeftColor: isSelected ? "#137ddb" : "transparent",
+									background: isSelected ? "rgba(19,125,219,0.04)" : undefined,
+								}}
+							>
+								<span
+									className="font-sans font-bold text-[14px] md:text-[13px] w-5 md:w-5 flex-shrink-0 text-right mt-[2px] transition"
+									style={{ color: isSelected ? "#137ddb" : "#94a3b8" }}
+								>
+									{verse.verseNumber}
+								</span>
+								<span
+									data-testid="verse-text"
+									className="flex-1 font-serif leading-[1.85] transition text-[#1a1a1a] dark:text-slate-100"
+									style={{ fontSize: "17px" }}
+								>
+									{verse.text}
+								</span>
+								{count > 0 && (
+									<span className="hidden md:flex flex-shrink-0 items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand">
+										<svg
+											width="9"
+											height="9"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="#fff"
+											strokeWidth="2.5"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										>
+											<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+										</svg>
+										<span className="font-bold text-[11px] text-white leading-[11px]">
+											{count}
+										</span>
+									</span>
+								)}
+							</button>
+							{count > 0 && (
+								<span
+									aria-hidden="true"
+									className="md:hidden absolute right-2 bottom-1.5 flex items-center gap-1 h-[15px] px-2 rounded-[20px] bg-brand pointer-events-none"
+								>
+									<svg
+										width="9"
+										height="9"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="#fff"
+										strokeWidth="2.5"
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									>
+										<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+									</svg>
+									<span className="font-bold text-[11px] text-white leading-[11px]">
+										{count}
+									</span>
+								</span>
+							)}
+							<div className="absolute right-[-10px] top-1 rounded-md bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm md:opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity opacity-60">
+								<CopyVerseButton
+									verse={{
+										abbrev,
+										chapter,
+										verseNumber: verse.verseNumber,
+										text: verse.text,
+									}}
+									label=""
+									className="!px-1.5 !py-1"
+								/>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
 }

--- a/nextjs/src/lib/manifest.test.ts
+++ b/nextjs/src/lib/manifest.test.ts
@@ -43,4 +43,17 @@ describe("manifest.webmanifest", () => {
 		expect(manifest.icons.length).toBeGreaterThanOrEqual(2);
 		expect(manifest.screenshots.length).toBeGreaterThanOrEqual(1);
 	});
+
+	// Task E: point browser install prompts at the published Play app instead
+	// of offering the (inferior) PWA install on Android.
+	it("prefers the related Play app for install", () => {
+		expect(manifest.prefer_related_applications).toBe(true);
+		expect(manifest.related_applications).toEqual([
+			{
+				platform: "play",
+				url: "https://play.google.com/store/apps/details?id=br.com.biblecomment.app",
+				id: "br.com.biblecomment.app",
+			},
+		]);
+	});
 });

--- a/nextjs/src/lib/offline/bibleStore.ts
+++ b/nextjs/src/lib/offline/bibleStore.ts
@@ -114,7 +114,8 @@ export async function isBookSynced(
     "readonly",
     (s) => s.get(abbrev),
   );
-  return !!book && book.version === version;
+  // Optional chaining narrows cleanly: undefined book → undefined !== version.
+  return book?.version === version;
 }
 
 /** Drop the entire offline dataset (toggle off / quota cleanup). */

--- a/nextjs/src/lib/offline/bibleStore.ts
+++ b/nextjs/src/lib/offline/bibleStore.ts
@@ -15,111 +15,111 @@ export type StoredBook = { chapters: BookChapters; version: string };
 
 export type SyncStatus = "idle" | "syncing" | "ready" | "partial" | "off";
 export type OfflineMeta = {
-  version: string;
-  syncedAt: number;
-  status: SyncStatus;
+	version: string;
+	syncedAt: number;
+	status: SyncStatus;
 };
 
 function openDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onupgradeneeded = () => {
-      const db = req.result;
-      // `books` keyed by abbrev; the stored value is { chapters, version }.
-      if (!db.objectStoreNames.contains(BOOKS_STORE)) {
-        db.createObjectStore(BOOKS_STORE);
-      }
-      // `meta` holds a single record under META_KEY.
-      if (!db.objectStoreNames.contains(META_STORE)) {
-        db.createObjectStore(META_STORE);
-      }
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
+	return new Promise((resolve, reject) => {
+		const req = indexedDB.open(DB_NAME, DB_VERSION);
+		req.onupgradeneeded = () => {
+			const db = req.result;
+			// `books` keyed by abbrev; the stored value is { chapters, version }.
+			if (!db.objectStoreNames.contains(BOOKS_STORE)) {
+				db.createObjectStore(BOOKS_STORE);
+			}
+			// `meta` holds a single record under META_KEY.
+			if (!db.objectStoreNames.contains(META_STORE)) {
+				db.createObjectStore(META_STORE);
+			}
+		};
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+	});
 }
 
 // Promisify a single get/put against one store. `mode` picks the txn type.
 function withStore<T>(
-  store: string,
-  mode: IDBTransactionMode,
-  fn: (s: IDBObjectStore) => IDBRequest<T>,
+	store: string,
+	mode: IDBTransactionMode,
+	fn: (s: IDBObjectStore) => IDBRequest<T>,
 ): Promise<T> {
-  return openDB().then(
-    (db) =>
-      new Promise<T>((resolve, reject) => {
-        const tx = db.transaction(store, mode);
-        const req = fn(tx.objectStore(store));
-        req.onsuccess = () => resolve(req.result);
-        req.onerror = () => reject(req.error);
-        tx.oncomplete = () => db.close();
-        tx.onerror = () => reject(tx.error);
-        // QuotaExceededError surfaces on the transaction's abort, not the
-        // request — propagate it so callers (bibleSync) can react.
-        tx.onabort = () => reject(tx.error);
-      }),
-  );
+	return openDB().then(
+		(db) =>
+			new Promise<T>((resolve, reject) => {
+				const tx = db.transaction(store, mode);
+				const req = fn(tx.objectStore(store));
+				req.onsuccess = () => resolve(req.result);
+				req.onerror = () => reject(req.error);
+				tx.oncomplete = () => db.close();
+				tx.onerror = () => reject(tx.error);
+				// QuotaExceededError surfaces on the transaction's abort, not the
+				// request — propagate it so callers (bibleSync) can react.
+				tx.onabort = () => reject(tx.error);
+			}),
+	);
 }
 
 /** Verses for one chapter of a stored book, or null if not present. */
 export async function getChapter(
-  abbrev: string,
-  chapter: number,
+	abbrev: string,
+	chapter: number,
 ): Promise<ChapterVerse[] | null> {
-  const book = await withStore<StoredBook | undefined>(
-    BOOKS_STORE,
-    "readonly",
-    (s) => s.get(abbrev),
-  );
-  if (!book) return null;
-  return book.chapters[String(chapter)] ?? null;
+	const book = await withStore<StoredBook | undefined>(
+		BOOKS_STORE,
+		"readonly",
+		(s) => s.get(abbrev),
+	);
+	if (!book) return null;
+	return book.chapters[String(chapter)] ?? null;
 }
 
 /** Write a whole book's chapters under its abbrev, tagged with `version`. */
 export async function putBook(
-  abbrev: string,
-  data: { chapters: BookChapters },
-  version: string,
+	abbrev: string,
+	data: { chapters: BookChapters },
+	version: string,
 ): Promise<void> {
-  const value: StoredBook = { chapters: data.chapters, version };
-  await withStore<IDBValidKey>(BOOKS_STORE, "readwrite", (s) =>
-    s.put(value, abbrev),
-  );
+	const value: StoredBook = { chapters: data.chapters, version };
+	await withStore<IDBValidKey>(BOOKS_STORE, "readwrite", (s) =>
+		s.put(value, abbrev),
+	);
 }
 
 /** The single offline-sync meta record, or null before the first sync. */
 export async function getMeta(): Promise<OfflineMeta | null> {
-  const meta = await withStore<OfflineMeta | undefined>(
-    META_STORE,
-    "readonly",
-    (s) => s.get(META_KEY),
-  );
-  return meta ?? null;
+	const meta = await withStore<OfflineMeta | undefined>(
+		META_STORE,
+		"readonly",
+		(s) => s.get(META_KEY),
+	);
+	return meta ?? null;
 }
 
 /** Persist the offline-sync meta record. */
 export async function setMeta(meta: OfflineMeta): Promise<void> {
-  await withStore<IDBValidKey>(META_STORE, "readwrite", (s) =>
-    s.put(meta, META_KEY),
-  );
+	await withStore<IDBValidKey>(META_STORE, "readwrite", (s) =>
+		s.put(meta, META_KEY),
+	);
 }
 
 /** True only when the book is stored AND tagged with the expected version. */
 export async function isBookSynced(
-  abbrev: string,
-  version: string,
+	abbrev: string,
+	version: string,
 ): Promise<boolean> {
-  const book = await withStore<StoredBook | undefined>(
-    BOOKS_STORE,
-    "readonly",
-    (s) => s.get(abbrev),
-  );
-  // Optional chaining narrows cleanly: undefined book → undefined !== version.
-  return book?.version === version;
+	const book = await withStore<StoredBook | undefined>(
+		BOOKS_STORE,
+		"readonly",
+		(s) => s.get(abbrev),
+	);
+	// Optional chaining narrows cleanly: undefined book → undefined !== version.
+	return book?.version === version;
 }
 
 /** Drop the entire offline dataset (toggle off / quota cleanup). */
 export async function clearStore(): Promise<void> {
-  await withStore<undefined>(BOOKS_STORE, "readwrite", (s) => s.clear());
-  await withStore<undefined>(META_STORE, "readwrite", (s) => s.clear());
+	await withStore<undefined>(BOOKS_STORE, "readwrite", (s) => s.clear());
+	await withStore<undefined>(META_STORE, "readwrite", (s) => s.clear());
 }

--- a/nextjs/src/lib/offline/bibleSync.test.ts
+++ b/nextjs/src/lib/offline/bibleSync.test.ts
@@ -38,8 +38,7 @@ function routeFetch(url: string): Response {
 
 describe("syncOfflineBible", () => {
 	beforeEach(() => {
-		// eslint-disable-next-line no-global-assign
-		indexedDB = new IDBFactory();
+		vi.stubGlobal("indexedDB", new IDBFactory());
 		vi.restoreAllMocks();
 	});
 	afterEach(() => vi.restoreAllMocks());

--- a/nextjs/src/lib/offline/bibleSync.test.ts
+++ b/nextjs/src/lib/offline/bibleSync.test.ts
@@ -13,25 +13,26 @@ const BOOKS = [
 function booksResponse() {
   return {
     ok: true,
-    json: async () => ({ books: BOOKS, version: VERSION }),
+    json: () => Promise.resolve({ books: BOOKS, version: VERSION }),
   } as Response;
 }
 
 function bookVersesResponse(abbrev: string) {
   return {
     ok: true,
-    json: async () => ({
-      abbrev,
-      chapters: { "1": [{ n: 1, t: `${abbrev} 1:1` }] },
-    }),
+    json: () =>
+      Promise.resolve({
+        abbrev,
+        chapters: { "1": [{ n: 1, t: `${abbrev} 1:1` }] },
+      }),
   } as Response;
 }
 
 // Routes a fetch URL to the right canned response.
 function routeFetch(url: string): Response {
   if (url === "/api/books") return booksResponse();
-  const m = url.match(/^\/api\/books\/([^/]+)\/verses$/);
-  if (m) return bookVersesResponse(m[1]);
+  const match = url.match(/^\/api\/books\/([^/]+)\/verses$/);
+  if (match) return bookVersesResponse(match[1]);
   throw new Error(`unexpected fetch ${url}`);
 }
 

--- a/nextjs/src/lib/offline/bibleSync.test.ts
+++ b/nextjs/src/lib/offline/bibleSync.test.ts
@@ -6,126 +6,126 @@ import { putBook, getMeta, getChapter, isBookSynced } from "./bibleStore";
 
 const VERSION = "v1.abc";
 const BOOKS = [
-  { abbrev: "gn", chapters: 1 },
-  { abbrev: "ex", chapters: 1 },
+	{ abbrev: "gn", chapters: 1 },
+	{ abbrev: "ex", chapters: 1 },
 ];
 
 function booksResponse() {
-  return {
-    ok: true,
-    json: () => Promise.resolve({ books: BOOKS, version: VERSION }),
-  } as Response;
+	return {
+		ok: true,
+		json: () => Promise.resolve({ books: BOOKS, version: VERSION }),
+	} as Response;
 }
 
 function bookVersesResponse(abbrev: string) {
-  return {
-    ok: true,
-    json: () =>
-      Promise.resolve({
-        abbrev,
-        chapters: { "1": [{ n: 1, t: `${abbrev} 1:1` }] },
-      }),
-  } as Response;
+	return {
+		ok: true,
+		json: () =>
+			Promise.resolve({
+				abbrev,
+				chapters: { "1": [{ n: 1, t: `${abbrev} 1:1` }] },
+			}),
+	} as Response;
 }
 
 // Routes a fetch URL to the right canned response.
 function routeFetch(url: string): Response {
-  if (url === "/api/books") return booksResponse();
-  const match = url.match(/^\/api\/books\/([^/]+)\/verses$/);
-  if (match) return bookVersesResponse(match[1]);
-  throw new Error(`unexpected fetch ${url}`);
+	if (url === "/api/books") return booksResponse();
+	const match = url.match(/^\/api\/books\/([^/]+)\/verses$/);
+	if (match) return bookVersesResponse(match[1]);
+	throw new Error(`unexpected fetch ${url}`);
 }
 
 describe("syncOfflineBible", () => {
-  beforeEach(() => {
-    // eslint-disable-next-line no-global-assign
-    indexedDB = new IDBFactory();
-    vi.restoreAllMocks();
-  });
-  afterEach(() => vi.restoreAllMocks());
+	beforeEach(() => {
+		// eslint-disable-next-line no-global-assign
+		indexedDB = new IDBFactory();
+		vi.restoreAllMocks();
+	});
+	afterEach(() => vi.restoreAllMocks());
 
-  it("downloads only the missing books and marks ready", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string) => Promise.resolve(routeFetch(url)));
-    vi.stubGlobal("fetch", fetchMock);
+	it("downloads only the missing books and marks ready", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockImplementation((url: string) => Promise.resolve(routeFetch(url)));
+		vi.stubGlobal("fetch", fetchMock);
 
-    await syncOfflineBible({ enabled: true });
+		await syncOfflineBible({ enabled: true });
 
-    expect(await getChapter("gn", 1)).toEqual([{ n: 1, t: "gn 1:1" }]);
-    expect(await getChapter("ex", 1)).toEqual([{ n: 1, t: "ex 1:1" }]);
-    const meta = await getMeta();
-    expect(meta?.status).toBe("ready");
-    expect(meta?.version).toBe(VERSION);
-    // /api/books once + one per book.
-    const fetchedBookUrls = fetchMock.mock.calls
-      .map((c) => c[0] as string)
-      .filter((u) => u.endsWith("/verses"));
-    expect(fetchedBookUrls.sort()).toEqual([
-      "/api/books/ex/verses",
-      "/api/books/gn/verses",
-    ]);
-  });
+		expect(await getChapter("gn", 1)).toEqual([{ n: 1, t: "gn 1:1" }]);
+		expect(await getChapter("ex", 1)).toEqual([{ n: 1, t: "ex 1:1" }]);
+		const meta = await getMeta();
+		expect(meta?.status).toBe("ready");
+		expect(meta?.version).toBe(VERSION);
+		// /api/books once + one per book.
+		const fetchedBookUrls = fetchMock.mock.calls
+			.map((c) => c[0] as string)
+			.filter((u) => u.endsWith("/verses"));
+		expect(fetchedBookUrls.sort()).toEqual([
+			"/api/books/ex/verses",
+			"/api/books/gn/verses",
+		]);
+	});
 
-  it("is a no-op when version matches and all books are present", async () => {
-    await putBook("gn", { chapters: { "1": [{ n: 1, t: "x" }] } }, VERSION);
-    await putBook("ex", { chapters: { "1": [{ n: 1, t: "y" }] } }, VERSION);
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string) => Promise.resolve(routeFetch(url)));
-    vi.stubGlobal("fetch", fetchMock);
+	it("is a no-op when version matches and all books are present", async () => {
+		await putBook("gn", { chapters: { "1": [{ n: 1, t: "x" }] } }, VERSION);
+		await putBook("ex", { chapters: { "1": [{ n: 1, t: "y" }] } }, VERSION);
+		const fetchMock = vi
+			.fn()
+			.mockImplementation((url: string) => Promise.resolve(routeFetch(url)));
+		vi.stubGlobal("fetch", fetchMock);
 
-    await syncOfflineBible({ enabled: true });
+		await syncOfflineBible({ enabled: true });
 
-    // Only /api/books fetched; no per-book downloads.
-    const bookFetches = fetchMock.mock.calls
-      .map((c) => c[0] as string)
-      .filter((u) => u.endsWith("/verses"));
-    expect(bookFetches).toEqual([]);
-    expect((await getMeta())?.status).toBe("ready");
-  });
+		// Only /api/books fetched; no per-book downloads.
+		const bookFetches = fetchMock.mock.calls
+			.map((c) => c[0] as string)
+			.filter((u) => u.endsWith("/verses"));
+		expect(bookFetches).toEqual([]);
+		expect((await getMeta())?.status).toBe("ready");
+	});
 
-  it("only fetches books that aren't already synced (resumable)", async () => {
-    await putBook("gn", { chapters: { "1": [{ n: 1, t: "x" }] } }, VERSION);
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string) => Promise.resolve(routeFetch(url)));
-    vi.stubGlobal("fetch", fetchMock);
+	it("only fetches books that aren't already synced (resumable)", async () => {
+		await putBook("gn", { chapters: { "1": [{ n: 1, t: "x" }] } }, VERSION);
+		const fetchMock = vi
+			.fn()
+			.mockImplementation((url: string) => Promise.resolve(routeFetch(url)));
+		vi.stubGlobal("fetch", fetchMock);
 
-    await syncOfflineBible({ enabled: true });
+		await syncOfflineBible({ enabled: true });
 
-    const bookFetches = fetchMock.mock.calls
-      .map((c) => c[0] as string)
-      .filter((u) => u.endsWith("/verses"));
-    expect(bookFetches).toEqual(["/api/books/ex/verses"]);
-    expect(await isBookSynced("ex", VERSION)).toBe(true);
-  });
+		const bookFetches = fetchMock.mock.calls
+			.map((c) => c[0] as string)
+			.filter((u) => u.endsWith("/verses"));
+		expect(bookFetches).toEqual(["/api/books/ex/verses"]);
+		expect(await isBookSynced("ex", VERSION)).toBe(true);
+	});
 
-  it("preserves partial progress on a network drop and marks partial", async () => {
-    const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (url === "/api/books") return Promise.resolve(booksResponse());
-      if (url === "/api/books/gn/verses")
-        return Promise.resolve(bookVersesResponse("gn"));
-      // ex fails — simulate a dropped connection mid-sync.
-      return Promise.reject(new Error("network down"));
-    });
-    vi.stubGlobal("fetch", fetchMock);
+	it("preserves partial progress on a network drop and marks partial", async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string) => {
+			if (url === "/api/books") return Promise.resolve(booksResponse());
+			if (url === "/api/books/gn/verses")
+				return Promise.resolve(bookVersesResponse("gn"));
+			// ex fails — simulate a dropped connection mid-sync.
+			return Promise.reject(new Error("network down"));
+		});
+		vi.stubGlobal("fetch", fetchMock);
 
-    await syncOfflineBible({ enabled: true });
+		await syncOfflineBible({ enabled: true });
 
-    // gn persisted, ex absent, status reflects the incomplete run.
-    expect(await getChapter("gn", 1)).toEqual([{ n: 1, t: "gn 1:1" }]);
-    expect(await getChapter("ex", 1)).toBeNull();
-    expect((await getMeta())?.status).toBe("partial");
-  });
+		// gn persisted, ex absent, status reflects the incomplete run.
+		expect(await getChapter("gn", 1)).toEqual([{ n: 1, t: "gn 1:1" }]);
+		expect(await getChapter("ex", 1)).toBeNull();
+		expect((await getMeta())?.status).toBe("partial");
+	});
 
-  it("does nothing when the toggle is off", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+	it("does nothing when the toggle is off", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
 
-    await syncOfflineBible({ enabled: false });
+		await syncOfflineBible({ enabled: false });
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(await getMeta()).toBeNull();
-  });
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(await getMeta()).toBeNull();
+	});
 });

--- a/nextjs/src/lib/offline/content-version.test.ts
+++ b/nextjs/src/lib/offline/content-version.test.ts
@@ -3,44 +3,46 @@ import { computeContentVersion, CONTENT_VERSION_SALT } from "./content-version";
 import type { Book } from "@/domain/entities/Book";
 
 function book(abbrev: string, chapters: number): Book {
-  return {
-    abbrev,
-    chapters,
-    name: abbrev.toUpperCase(),
-    author: "x",
-    group: "g",
-    testament: "VT",
-  };
+	return {
+		abbrev,
+		chapters,
+		name: abbrev.toUpperCase(),
+		author: "x",
+		group: "g",
+		testament: "VT",
+	};
 }
 
 describe("computeContentVersion", () => {
-  it("returns a stable, non-empty string for the same corpus", () => {
-    const books = [book("gn", 50), book("ex", 40)];
-    const first = computeContentVersion(books);
-    const second = computeContentVersion([...books]);
-    expect(first).toBe(second);
-    expect(first.length).toBeGreaterThan(0);
-  });
+	it("returns a stable, non-empty string for the same corpus", () => {
+		const books = [book("gn", 50), book("ex", 40)];
+		const first = computeContentVersion(books);
+		const second = computeContentVersion([...books]);
+		expect(first).toBe(second);
+		expect(first.length).toBeGreaterThan(0);
+	});
 
-  it("is order-independent (sorts before hashing)", () => {
-    const ascending = computeContentVersion([book("gn", 50), book("ex", 40)]);
-    const descending = computeContentVersion([book("ex", 40), book("gn", 50)]);
-    expect(ascending).toBe(descending);
-  });
+	it("is order-independent (sorts before hashing)", () => {
+		const ascending = computeContentVersion([book("gn", 50), book("ex", 40)]);
+		const descending = computeContentVersion([book("ex", 40), book("gn", 50)]);
+		expect(ascending).toBe(descending);
+	});
 
-  it("changes when a book's chapter count changes", () => {
-    const before = computeContentVersion([book("gn", 50)]);
-    const after = computeContentVersion([book("gn", 51)]);
-    expect(before).not.toBe(after);
-  });
+	it("changes when a book's chapter count changes", () => {
+		const before = computeContentVersion([book("gn", 50)]);
+		const after = computeContentVersion([book("gn", 51)]);
+		expect(before).not.toBe(after);
+	});
 
-  it("changes when the number of books changes", () => {
-    const oneBook = computeContentVersion([book("gn", 50)]);
-    const twoBooks = computeContentVersion([book("gn", 50), book("ex", 40)]);
-    expect(oneBook).not.toBe(twoBooks);
-  });
+	it("changes when the number of books changes", () => {
+		const oneBook = computeContentVersion([book("gn", 50)]);
+		const twoBooks = computeContentVersion([book("gn", 50), book("ex", 40)]);
+		expect(oneBook).not.toBe(twoBooks);
+	});
 
-  it("embeds the salt so verse-only corrections can force a re-sync", () => {
-    expect(computeContentVersion([book("gn", 50)])).toContain(CONTENT_VERSION_SALT);
-  });
+	it("embeds the salt so verse-only corrections can force a re-sync", () => {
+		expect(computeContentVersion([book("gn", 50)])).toContain(
+			CONTENT_VERSION_SALT,
+		);
+	});
 });

--- a/nextjs/src/lib/offline/content-version.test.ts
+++ b/nextjs/src/lib/offline/content-version.test.ts
@@ -16,28 +16,28 @@ function book(abbrev: string, chapters: number): Book {
 describe("computeContentVersion", () => {
   it("returns a stable, non-empty string for the same corpus", () => {
     const books = [book("gn", 50), book("ex", 40)];
-    const a = computeContentVersion(books);
-    const b = computeContentVersion([...books]);
-    expect(a).toBe(b);
-    expect(a.length).toBeGreaterThan(0);
+    const first = computeContentVersion(books);
+    const second = computeContentVersion([...books]);
+    expect(first).toBe(second);
+    expect(first.length).toBeGreaterThan(0);
   });
 
   it("is order-independent (sorts before hashing)", () => {
-    const a = computeContentVersion([book("gn", 50), book("ex", 40)]);
-    const b = computeContentVersion([book("ex", 40), book("gn", 50)]);
-    expect(a).toBe(b);
+    const ascending = computeContentVersion([book("gn", 50), book("ex", 40)]);
+    const descending = computeContentVersion([book("ex", 40), book("gn", 50)]);
+    expect(ascending).toBe(descending);
   });
 
   it("changes when a book's chapter count changes", () => {
-    const a = computeContentVersion([book("gn", 50)]);
-    const b = computeContentVersion([book("gn", 51)]);
-    expect(a).not.toBe(b);
+    const before = computeContentVersion([book("gn", 50)]);
+    const after = computeContentVersion([book("gn", 51)]);
+    expect(before).not.toBe(after);
   });
 
   it("changes when the number of books changes", () => {
-    const a = computeContentVersion([book("gn", 50)]);
-    const b = computeContentVersion([book("gn", 50), book("ex", 40)]);
-    expect(a).not.toBe(b);
+    const oneBook = computeContentVersion([book("gn", 50)]);
+    const twoBooks = computeContentVersion([book("gn", 50), book("ex", 40)]);
+    expect(oneBook).not.toBe(twoBooks);
   });
 
   it("embeds the salt so verse-only corrections can force a re-sync", () => {


### PR DESCRIPTION
Post-ship cleanup for the offline-Bible feature (already on master). Three independent concerns, one commit each; all validated locally.

## test(verify-email): de-flake
Fixes two pre-existing races that intermittently fail CI (unrelated to the offline feature):
- `fetchLatestVerificationEmail` now **polls** the dev inbox (retry until the email lands) instead of reading once and throwing on an empty inbox.
- The verified-badge assertion gets a 10s timeout to survive full-suite CI load.

Validated: `verify-email.cy.ts` **5/5 on two consecutive local `cy:test` runs** (previously failed reliably on the inbox race).

## chore(deps): patch vite + ws CVEs
`overrides`: **vite 8.0.10→8.0.16** (server.fs.deny bypass) and **ws→8.21.0** (DoS / memory disclosure). Both dev/build-only (vitest, lighthouse, puppeteer). `npm audit`: **25→23 vulns, 9→7 high**. Full Vitest (537) green. The remaining advisories are deeper dev-tooling transitives that need riskier major bumps.

## chore(deepsource): clear new lint issues in offline code
Descriptive variable names, drop unused `states` destructure, `async`-without-await mocks → `Promise.resolve`. The `!!`→`Boolean()` swap broke TS narrowing in `bibleStore`, so `isBookSynced` uses optional chaining (`book?.version === version`) instead — cleaner and it narrows.

Local gates: `tsc`, **537 Vitest**, verify-email **5/5 ×2**. Full CI (unit + cypress + a11y) runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
